### PR TITLE
Feature/Login failure hadler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/dnd/studyplanner/auth/AuthController.java
+++ b/src/main/java/dnd/studyplanner/auth/AuthController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import dnd.studyplanner.auth.dto.TokenResponseDto;
-import dnd.studyplanner.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,7 +24,7 @@ public class AuthController {
 	public TokenResponseDto reissueAccessToken(
 		@RequestHeader(value = "Refresh-Token") String refreshToken
 	) {
-		if (authService.isExpiredToken(refreshToken)) { // Refresh Token이 만료된 경우
+		if (authService.isExpiredRefreshToken(refreshToken)) { // Refresh Token이 만료된 경우
 			log.debug("[REFRESH TOKEN EXPIRED] : {} is expired. Please Login again", refreshToken);
 			return null; // Response 에 대한 규격을 정하고, ERROR CODE 추가해서 응답하면 좋을 것 같습니다!
 		}
@@ -35,12 +34,18 @@ public class AuthController {
 	}
 
 	@GetMapping("/after/login")
-	public void afterLoginTest(
-		@RequestParam(value = "access_token") String access_token,
-		@RequestParam(value = "refresh_token") String refresh_token
+	public void afterLoginTest( //login 여부 테스트
+		@RequestParam(value = "success") boolean success,
+		@RequestParam(value = "token", required = false) String token,
+		@RequestParam(value = "refresh", required = false) String refresh
 	) {
-		log.debug("[ACCESS TOKEN] : {}", access_token);
-		log.debug("[REFRESH ACCESS TOKEN] : {}", refresh_token);
-	}
+		if (success) {
+			log.debug("[LOGIN RESULT] : {}", true);
+			log.debug("[ACCESS TOKEN] : {}", token);
+			log.debug("[REFRESH ACCESS TOKEN] : {}", refresh);
+		} else {
+			log.debug("[LOGIN RESULT] : {}", false);
+		}
 
+	}
 }

--- a/src/main/java/dnd/studyplanner/auth/AuthService.java
+++ b/src/main/java/dnd/studyplanner/auth/AuthService.java
@@ -1,7 +1,5 @@
 package dnd.studyplanner.auth;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 
 import dnd.studyplanner.auth.dto.TokenResponseDto;
@@ -19,8 +17,8 @@ public class AuthService {
 	private final AuthRepository authRepository;
 	private final JwtService jwtService;
 
-	public boolean isExpiredToken(String refreshToken) {
-		return jwtService.isExpired(refreshToken);
+	public boolean isExpiredRefreshToken(String refreshToken) {
+		return jwtService.isExpiredRefreshToken(refreshToken);
 	}
 
 

--- a/src/main/java/dnd/studyplanner/auth/AuthService.java
+++ b/src/main/java/dnd/studyplanner/auth/AuthService.java
@@ -17,17 +17,13 @@ public class AuthService {
 	private final AuthRepository authRepository;
 	private final JwtService jwtService;
 
-	public boolean isExpiredRefreshToken(String refreshToken) {
-		return jwtService.isExpiredRefreshToken(refreshToken);
-	}
-
 
 	public TokenResponseDto reissueAccessToken(String refreshToken) {
-		Long memberId = jwtService.getMemberId(refreshToken);
+		Long memberId = jwtService.getMemberIdFromRefresh(refreshToken);
 		String newAccessToken = jwtService.createJwt(memberId); //새로운 Access-Token 생성
 		String newRefreshToken = refreshToken;
 		if (jwtService.isUpdatableRefreshToken(refreshToken)) { //Refresh-Token 만료 시간에 따라 재발급
-			log.debug("[REFRESH TOKEN REFRESH] : {} \n to {}", refreshToken, newRefreshToken);
+			log.debug("[REFRESH TOKEN REFRESH] : \n{} \n to {}", refreshToken, newRefreshToken);
 			newRefreshToken = jwtService.createRefreshToken(memberId);
 		};
 

--- a/src/main/java/dnd/studyplanner/config/Constant.java
+++ b/src/main/java/dnd/studyplanner/config/Constant.java
@@ -1,0 +1,28 @@
+package dnd.studyplanner.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Constant {
+
+	public static String JWT_SECRET_KEY;
+
+	public static String REFRESH_SECRET_KEY;
+
+	public static String CLIENT_DOMAIN;
+
+	public static final int JWT_EXPIRATION = 1000 * 60 * 60 * 2; //2시간
+	public static final int REFRESH_EXPIRATION = 1000 * 60 * 60 * 24 * 7 * 2; //14일 (2주)
+	public static final int WEEKS = 1000 * 60 * 60 * 24 * 7; // 7일
+
+	public Constant(
+		@Value("${jwt.secret}") String jwtSecretKey,
+		@Value("${jwt.refresh-secret}") String refreshSecretKey,
+		@Value("${front-client.domain}") String clientDomain
+	) {
+		JWT_SECRET_KEY = jwtSecretKey;
+		REFRESH_SECRET_KEY = refreshSecretKey;
+		CLIENT_DOMAIN = clientDomain;
+	}
+}

--- a/src/main/java/dnd/studyplanner/config/OAuth2FailureHandler.java
+++ b/src/main/java/dnd/studyplanner/config/OAuth2FailureHandler.java
@@ -1,0 +1,32 @@
+package dnd.studyplanner.config;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException, ServletException {
+		super.onAuthenticationFailure(request, response, exception);
+
+
+		String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/auth/after/login")
+			.queryParam("success", false)
+			.queryParam("error", exception.getLocalizedMessage())
+			.build().toUriString();
+
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+
+}

--- a/src/main/java/dnd/studyplanner/config/OAuth2FailureHandler.java
+++ b/src/main/java/dnd/studyplanner/config/OAuth2FailureHandler.java
@@ -1,5 +1,7 @@
 package dnd.studyplanner.config;
 
+import static dnd.studyplanner.config.Constant.*;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
@@ -21,7 +23,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
 		super.onAuthenticationFailure(request, response, exception);
 
 
-		String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/auth/after/login")
+		String targetUrl = UriComponentsBuilder.fromUriString(CLIENT_DOMAIN + "/login")
 			.queryParam("success", false)
 			.queryParam("error", exception.getLocalizedMessage())
 			.build().toUriString();

--- a/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
@@ -44,26 +44,21 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		// registrationId 추출이 어려워 정규표현식으로 email 파싱 -> 서비스마다 email이 담겨있는 형식이 달라서..
 		String email = findEmailByRegex(attributes.toString());
 
-		log.debug("[USER EMAIL] : {}", email);
-
 		Long memberId = memberRepository.findByEmail(email).get().getId();
 
 		AuthEntity authEntity = authRepository.findById(memberId).get();
 		String accessToken = authEntity.getJwt();
 		String refreshToken = authEntity.getRefreshToken();
 
-		log.info("토큰 발행 시작");
-		response.setContentType("application/json");
-		response.setCharacterEncoding("utf-8");
+		log.debug("[USER EMAIL] : {}", email);
+		log.debug("[TOKEN] : {}", accessToken);
+		log.debug("[REFRESH_TOKEN] : {}", refreshToken);
 
-		TokenResponseDto tokenDto = new TokenResponseDto(accessToken, refreshToken);
-		// json 형태로 바꾸기
-		String result = objectMapper.writeValueAsString(tokenDto);
-		response.getWriter().write(result);
 
 		String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/auth/after/login")
-			.queryParam("access_token", accessToken)
-			.queryParam("refresh_token", refreshToken)
+			.queryParam("success", true)
+			.queryParam("token", accessToken)
+			.queryParam("refresh", refreshToken)
 			.build().toUriString();
 
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
@@ -80,7 +75,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			if (m.group(1) != null) {
 				break;
 			}
-			;
 		}
 
 		return m.group(1);

--- a/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
@@ -1,5 +1,7 @@
 package dnd.studyplanner.config;
 
+import static dnd.studyplanner.config.Constant.*;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -55,7 +57,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		log.debug("[REFRESH_TOKEN] : {}", refreshToken);
 
 
-		String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/auth/after/login")
+		String targetUrl = UriComponentsBuilder.fromUriString(CLIENT_DOMAIN + "/login")
 			.queryParam("success", true)
 			.queryParam("token", accessToken)
 			.queryParam("refresh", refreshToken)

--- a/src/main/java/dnd/studyplanner/config/SwaggerConfig.java
+++ b/src/main/java/dnd/studyplanner/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package dnd.studyplanner.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+	@Bean
+	public Docket restAPI() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.apiInfo(apiInfo())
+			.select()
+			.apis(RequestHandlerSelectors.basePackage("dnd.studyplanner"))
+			.paths(PathSelectors.any())
+			.build();
+	}
+
+	private ApiInfo apiInfo() {
+		return new ApiInfoBuilder()
+			.title("DnD 7th-9 Spring Boot REST API")
+			.version("1.0.0")
+			.description("swagger api")
+			.build();
+	}
+}

--- a/src/main/java/dnd/studyplanner/jwt/JwtTokenInterceptor.java
+++ b/src/main/java/dnd/studyplanner/jwt/JwtTokenInterceptor.java
@@ -3,6 +3,7 @@ package dnd.studyplanner.jwt;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -25,8 +26,6 @@ public class JwtTokenInterceptor implements HandlerInterceptor {
 		log.debug("[JWT Token Interceptor]");
 		String accessToken = jwtService.getJwt(); // Header 에 있는 Token 추출
 		log.debug("[JWT] : {}", accessToken);
-		String refreshToken = jwtService.getRefreshToken(); // Header 에 있는 Refresh Token 추출
-		log.debug("[Refresh Token] : {}", refreshToken);
 
 		if (accessToken == null) {
 			log.warn("[JWT TOKEN EXCEPTION] : Token is not found");
@@ -36,7 +35,7 @@ public class JwtTokenInterceptor implements HandlerInterceptor {
 
 		} else {
 			if (jwtService.isExpired(accessToken)) {     // jwt 토큰이 만료된 경우
-				log.warn("[JWT TOKEN EXCEPTION] : {} is expired", accessToken);
+				log.warn("[JWT TOKEN EXPIRED] : {} is expired", accessToken);
 				httpServletResponse.setStatus(401);
 				httpServletResponse.setHeader("ACCESS_TOKEN", accessToken);
 				httpServletResponse.setHeader("msg", "ACCESS TOKEN EXPIRED");

--- a/src/main/java/dnd/studyplanner/jwt/JwtTokenInterceptor.java
+++ b/src/main/java/dnd/studyplanner/jwt/JwtTokenInterceptor.java
@@ -1,7 +1,5 @@
 package dnd.studyplanner.jwt;
 
-import java.io.IOException;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -31,10 +29,8 @@ public class JwtTokenInterceptor implements HandlerInterceptor {
 		log.debug("[Refresh Token] : {}", refreshToken);
 
 		if (accessToken == null) {
-			log.warn("[JWT TOKEN EXCEPTION] : {} is not found", accessToken);
+			log.warn("[JWT TOKEN EXCEPTION] : Token is not found");
 			httpServletResponse.setStatus(401);
-			httpServletResponse.setHeader("ACCESS_TOKEN", accessToken);
-			httpServletResponse.setHeader("REFRESH_TOKEN", refreshToken);
 			httpServletResponse.setHeader("msg", "Check the tokens.");
 			return false;
 
@@ -48,7 +44,7 @@ public class JwtTokenInterceptor implements HandlerInterceptor {
 
 			} else if (jwtService.isNotValid(accessToken)) {   // jwt 토큰이 유효하지 않은 경우
 				log.warn("[JWT TOKEN EXCEPTION] : {} is invalid", accessToken);
-				httpServletResponse.setStatus(401);
+				httpServletResponse.setStatus(409);
 				httpServletResponse.setHeader("ACCESS_TOKEN", accessToken);
 				httpServletResponse.setHeader("msg", "INVALID TOKEN");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher  # Swagger와 MVC 충돌 방지
 
 logging:
   level:


### PR DESCRIPTION
## Login 실패 핸들러 추가
- 실패시 지정해둔 Client Domain으로 리다이렉트
- Access, Refresh Key 값 분리
- Constant 클래스 생성 (도메인, Key 등 상수 보관)

## Token 검증 오류 수정
- 비정상적인 토큰에 대해 검증이 불가했던 오류 수정하였습니다

\+ Swagger 의존성만 추가해뒀습니다. (gradle에 추가)