### PR TITLE
데이터(QuestionBook, Question, Option)를 리스트 단위로 받아 처리하기. 방안(2)

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/OptionController.java
+++ b/src/main/java/dnd/studyplanner/controller/OptionController.java
@@ -1,0 +1,23 @@
+package dnd.studyplanner.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dnd.studyplanner.dto.option.request.OptionListSaveDto;
+import dnd.studyplanner.exception.BaseException;
+import dnd.studyplanner.service.OptionService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/option")
+@RestController
+public class OptionController {
+
+	private final OptionService optionService;
+
+	@PostMapping("/list")
+	public void addOptionAsList(OptionListSaveDto saveDto) throws BaseException {
+		optionService.saveOptions(saveDto);
+	}
+}

--- a/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
@@ -1,0 +1,27 @@
+package dnd.studyplanner.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dnd.studyplanner.dto.questionbook.request.QuestionBookSaveDto;
+import dnd.studyplanner.service.QuestionBookService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController("/question-book")
+public class QuestionBookController {
+
+	private final QuestionBookService questionBookService;
+
+	@PostMapping
+	public Long addQuestionBook(QuestionBookSaveDto saveDto) {
+		// 1. 검증
+
+		// questionBookService.saveQuestionBook(saveDto);
+		return 1L;
+	}
+
+
+}

--- a/src/main/java/dnd/studyplanner/controller/QuestionController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionController.java
@@ -1,0 +1,23 @@
+package dnd.studyplanner.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dnd.studyplanner.dto.question.request.QuestionSaveDto;
+import dnd.studyplanner.exception.BaseException;
+import dnd.studyplanner.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/question")
+@RestController
+public class QuestionController {
+
+	private final QuestionService questionService;
+
+	@PostMapping
+	public void addQuestion(QuestionSaveDto saveDto) throws BaseException {
+		questionService.saveQuestion(saveDto);
+	}
+}

--- a/src/main/java/dnd/studyplanner/domain/option/model/Option.java
+++ b/src/main/java/dnd/studyplanner/domain/option/model/Option.java
@@ -12,9 +12,13 @@ import javax.persistence.Table;
 
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.question.model.Question;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "options")
 public class Option extends BaseEntity {
@@ -31,4 +35,14 @@ public class Option extends BaseEntity {
 	private String optionContent;
 	private boolean optionImageEnable;
 	private String optionImageUrl;
+
+	@Builder
+	public Option(Question question, String optionContent, boolean optionImageEnable, String optionImageUrl) {
+		this.question = question;
+		this.optionContent = optionContent;
+		this.optionImageEnable = optionImageEnable;
+		this.optionImageUrl = optionImageUrl;
+
+		question.getOptions().add(this);
+	}
 }

--- a/src/main/java/dnd/studyplanner/domain/question/model/Question.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/Question.java
@@ -18,9 +18,13 @@ import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.option.model.Option;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Question extends BaseEntity {
 	@Id
@@ -41,4 +45,14 @@ public class Question extends BaseEntity {
 
 	@OneToMany(mappedBy = "solveQuestion", cascade = CascadeType.ALL)
 	private List<UserSolveQuestion> userSolveQuestions = new ArrayList<>();
+
+	@Builder
+	public Question(QuestionBook questionBook, String questionContent, int questionAnswer, String questionOptionType) {
+		this.questionBook = questionBook;
+		this.questionContent = questionContent;
+		this.questionAnswer = questionAnswer;
+		this.questionOptionType = questionOptionType;
+
+		questionBook.getQuestions().add(this);
+	}
 }

--- a/src/main/java/dnd/studyplanner/domain/question/model/Question.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/Question.java
@@ -6,6 +6,8 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -38,7 +40,8 @@ public class Question extends BaseEntity {
 
 	private String questionContent;
 	private int questionAnswer;
-	private String questionOptionType;
+	@Enumerated(EnumType.STRING)
+	private QuestionOptionType questionOptionType;
 
 	@OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
 	private List<Option> options = new ArrayList<>();
@@ -47,7 +50,7 @@ public class Question extends BaseEntity {
 	private List<UserSolveQuestion> userSolveQuestions = new ArrayList<>();
 
 	@Builder
-	public Question(QuestionBook questionBook, String questionContent, int questionAnswer, String questionOptionType) {
+	public Question(QuestionBook questionBook, String questionContent, int questionAnswer, QuestionOptionType questionOptionType) {
 		this.questionBook = questionBook;
 		this.questionContent = questionContent;
 		this.questionAnswer = questionAnswer;

--- a/src/main/java/dnd/studyplanner/domain/question/model/QuestionOptionType.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/QuestionOptionType.java
@@ -1,0 +1,6 @@
+package dnd.studyplanner.domain.question.model;
+
+public enum QuestionOptionType {
+	IMAGE,
+	TEXT
+}

--- a/src/main/java/dnd/studyplanner/domain/questionbook/model/QuestionBook.java
+++ b/src/main/java/dnd/studyplanner/domain/questionbook/model/QuestionBook.java
@@ -22,9 +22,13 @@ import dnd.studyplanner.domain.question.model.Question;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
 import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class QuestionBook extends BaseEntity {
 
@@ -53,4 +57,14 @@ public class QuestionBook extends BaseEntity {
 
 	@OneToMany(mappedBy = "solveQuestionBook", cascade = CascadeType.ALL)
 	private List<UserSolveQuestion> userSolveQuestions = new ArrayList<>();
+
+	@Builder
+	public QuestionBook(Goal questionBookGoal, User questionBookCreateUser, String questionBookName,
+		int questionBookMinAchieveRate, int questionBookQuestionNum) {
+		this.questionBookGoal = questionBookGoal;
+		this.questionBookCreateUser = questionBookCreateUser;
+		this.questionBookName = questionBookName;
+		this.questionBookMinAchieveRate = questionBookMinAchieveRate;
+		this.questionBookQuestionNum = questionBookQuestionNum;
+	}
 }

--- a/src/main/java/dnd/studyplanner/dto/option/request/OptionListSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/option/request/OptionListSaveDto.java
@@ -1,9 +1,11 @@
 package dnd.studyplanner.dto.option.request;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import dnd.studyplanner.domain.option.model.Option;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OptionListSaveDto {
 	private Long questionId;
-	private List<OptionSaveDto> options;
+	private List<OptionSaveDto> options = new ArrayList<>();
 
+	@Builder
+	public OptionListSaveDto(Long questionId, List<OptionSaveDto> options) {
+		this.questionId = questionId;
+		this.options = options;
+	}
 }

--- a/src/main/java/dnd/studyplanner/dto/option/request/OptionListSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/option/request/OptionListSaveDto.java
@@ -1,0 +1,16 @@
+package dnd.studyplanner.dto.option.request;
+
+import java.util.List;
+
+import dnd.studyplanner.domain.option.model.Option;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionListSaveDto {
+	private Long questionId;
+	private List<OptionSaveDto> options;
+
+}

--- a/src/main/java/dnd/studyplanner/dto/option/request/OptionSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/option/request/OptionSaveDto.java
@@ -1,0 +1,32 @@
+package dnd.studyplanner.dto.option.request;
+
+import dnd.studyplanner.domain.option.model.Option;
+import dnd.studyplanner.domain.question.model.Question;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionSaveDto {
+	private String optionContent;
+	private boolean optionImageEnable;
+	private String optionImageUrl;
+
+	@Builder
+	public OptionSaveDto(String optionContent, boolean optionImageEnable, String optionImageUrl) {
+		this.optionContent = optionContent;
+		this.optionImageEnable = optionImageEnable;
+		this.optionImageUrl = optionImageUrl;
+	}
+
+	public Option toEntity(Question question) {
+		return Option.builder()
+			.question(question)
+			.optionContent(this.optionContent)
+			.optionImageEnable(this.optionImageEnable)
+			.optionImageUrl(this.optionImageUrl)
+			.build();
+	}
+}

--- a/src/main/java/dnd/studyplanner/dto/question/request/QuestionListDto.java
+++ b/src/main/java/dnd/studyplanner/dto/question/request/QuestionListDto.java
@@ -1,8 +1,12 @@
 package dnd.studyplanner.dto.question.request;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import dnd.studyplanner.domain.question.model.Question;
 import dnd.studyplanner.domain.question.model.QuestionOptionType;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.option.request.OptionSaveDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,18 +14,20 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class QuestionSaveDto {
+public class QuestionListDto {
+
 	private int questionAnswer;
 	private String questionContent;
 	private QuestionOptionType questionOptionType;
-	private Long questionBookId;
+
+	private List<OptionSaveDto> optionSaveDtoList;
 
 	@Builder
-	public QuestionSaveDto(int questionAnswer, String questionContent, QuestionOptionType questionOptionType, Long questionBookId) {
+	public QuestionListDto(int questionAnswer, String questionContent, QuestionOptionType questionOptionType, List<OptionSaveDto> optionSaveDtoList) {
 		this.questionAnswer = questionAnswer;
 		this.questionContent = questionContent;
 		this.questionOptionType = questionOptionType;
-		this.questionBookId = questionBookId;
+		this.optionSaveDtoList = optionSaveDtoList;
 	}
 
 	public Question toEntity(QuestionBook questionBook) {
@@ -32,5 +38,4 @@ public class QuestionSaveDto {
 			.questionOptionType(this.questionOptionType)
 			.build();
 	}
-
 }

--- a/src/main/java/dnd/studyplanner/dto/question/request/QuestionSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/question/request/QuestionSaveDto.java
@@ -1,0 +1,35 @@
+package dnd.studyplanner.dto.question.request;
+
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionSaveDto {
+	private int questionAnswer;
+	private String questionContent;
+	private String questionOptionType;
+	private Long questionBookId;
+
+	@Builder
+	public QuestionSaveDto(int questionAnswer, String questionContent, String questionOptionType, Long questionBookId) {
+		this.questionAnswer = questionAnswer;
+		this.questionContent = questionContent;
+		this.questionOptionType = questionOptionType;
+		this.questionBookId = questionBookId;
+	}
+
+	public Question toEntity(QuestionBook questionBook) {
+		return Question.builder()
+			.questionContent(this.questionContent)
+			.questionAnswer(this.questionAnswer)
+			.questionBook(questionBook)
+			.questionOptionType(this.questionOptionType)
+			.build();
+	}
+
+}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookDto.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookDto.java
@@ -1,0 +1,23 @@
+package dnd.studyplanner.dto.questionbook.request;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dnd.studyplanner.dto.question.request.QuestionListDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionBookDto {
+
+	private Long goalId;
+	private Long createUserId;
+	private String questionBookName;
+	private int questionBookMinAchieveRate;
+	private int questionBookQuestionNum;
+
+	private List<QuestionListDto> questionDtoList = new ArrayList<>();
+
+}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookSaveDto.java
@@ -1,0 +1,35 @@
+package dnd.studyplanner.dto.questionbook.request;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.domain.user.model.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionBookSaveDto {
+	private Long goalId;
+	private Long createUserId;
+	private String questionBookName;
+	private int questionBookMinAchieveRate;
+	private int questionBookQuestionNum;
+
+	@Builder
+	public QuestionBookSaveDto(Long goalId, Long createUserId, String questionBookName, int questionBookMinAchieveRate,
+		int questionBookQuestionNum) {
+		this.goalId = goalId;
+		this.createUserId = createUserId;
+		this.questionBookName = questionBookName;
+		this.questionBookMinAchieveRate = questionBookMinAchieveRate;
+		this.questionBookQuestionNum = questionBookQuestionNum;
+	}
+
+	public QuestionBook toEntity(Goal goal, User createUser) {
+		return QuestionBook.builder()
+			.build();
+	}
+}

--- a/src/main/java/dnd/studyplanner/exception/BaseException.java
+++ b/src/main/java/dnd/studyplanner/exception/BaseException.java
@@ -1,0 +1,6 @@
+package dnd.studyplanner.exception;
+
+
+public class BaseException extends Exception {
+
+}

--- a/src/main/java/dnd/studyplanner/repository/OptionRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/OptionRepository.java
@@ -1,0 +1,9 @@
+package dnd.studyplanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.studyplanner.domain.option.model.Option;
+
+public interface OptionRepository extends JpaRepository<Option, Long> {
+
+}

--- a/src/main/java/dnd/studyplanner/repository/OptionRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/OptionRepository.java
@@ -1,9 +1,13 @@
 package dnd.studyplanner.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.studyplanner.domain.option.model.Option;
 
 public interface OptionRepository extends JpaRepository<Option, Long> {
+
+	List<Option> findOptionsByQuestion_Id(Long questionId);
 
 }

--- a/src/main/java/dnd/studyplanner/repository/QuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/QuestionBookRepository.java
@@ -1,0 +1,8 @@
+package dnd.studyplanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+
+public interface QuestionBookRepository extends JpaRepository<QuestionBook, Long> {
+}

--- a/src/main/java/dnd/studyplanner/repository/QuestionRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/QuestionRepository.java
@@ -1,0 +1,9 @@
+package dnd.studyplanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.studyplanner.domain.question.model.Question;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+}

--- a/src/main/java/dnd/studyplanner/service/OptionService.java
+++ b/src/main/java/dnd/studyplanner/service/OptionService.java
@@ -1,0 +1,39 @@
+package dnd.studyplanner.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import dnd.studyplanner.domain.option.model.Option;
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.dto.option.request.OptionListSaveDto;
+import dnd.studyplanner.dto.option.request.OptionSaveDto;
+import dnd.studyplanner.exception.BaseException;
+import dnd.studyplanner.repository.OptionRepository;
+import dnd.studyplanner.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class OptionService {
+
+	private final QuestionRepository questionRepository;
+	private final OptionRepository optionRepository;
+
+	public void saveOptions(OptionListSaveDto saveDto) throws BaseException {
+		Question question = questionRepository.findById(saveDto.getQuestionId())
+			.orElseThrow(BaseException::new);
+
+		List<Option> options = new ArrayList<>();
+		for (OptionSaveDto optionDto : saveDto.getOptions()) {
+			options.add(optionDto.toEntity(question));
+		}
+
+		optionRepository.saveAll(options);
+	}
+
+
+}

--- a/src/main/java/dnd/studyplanner/service/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/QuestionBookService.java
@@ -1,0 +1,21 @@
+package dnd.studyplanner.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import dnd.studyplanner.dto.questionbook.request.QuestionBookSaveDto;
+import dnd.studyplanner.repository.QuestionBookRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class QuestionBookService {
+
+	private final QuestionBookRepository questionBookRepository;
+
+
+	public void saveQuestionBook(QuestionBookSaveDto saveDto) {
+
+	}
+}

--- a/src/main/java/dnd/studyplanner/service/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/QuestionBookService.java
@@ -3,6 +3,7 @@ package dnd.studyplanner.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import dnd.studyplanner.dto.question.request.QuestionListDto;
 import dnd.studyplanner.dto.questionbook.request.QuestionBookSaveDto;
 import dnd.studyplanner.repository.QuestionBookRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ public class QuestionBookService {
 	private final QuestionBookRepository questionBookRepository;
 
 
-	public void saveQuestionBook(QuestionBookSaveDto saveDto) {
+	public void saveQuestionBook(QuestionListDto saveDto) {
 
 	}
 }

--- a/src/main/java/dnd/studyplanner/service/QuestionService.java
+++ b/src/main/java/dnd/studyplanner/service/QuestionService.java
@@ -1,0 +1,28 @@
+package dnd.studyplanner.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.question.request.QuestionSaveDto;
+import dnd.studyplanner.exception.BaseException;
+import dnd.studyplanner.repository.QuestionBookRepository;
+import dnd.studyplanner.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class QuestionService {
+
+	private final QuestionRepository questionRepository;
+	private final QuestionBookRepository questionBookRepository;
+
+	public Question saveQuestion(QuestionSaveDto saveDto) throws BaseException {
+		QuestionBook questionBook = questionBookRepository.findById(saveDto.getQuestionBookId())
+			.orElseThrow(BaseException::new);
+		Question question = saveDto.toEntity(questionBook);
+		return questionRepository.save(question);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     include: oauth, dev
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/dnd/studyplanner/DataUtil.java
+++ b/src/test/java/dnd/studyplanner/DataUtil.java
@@ -1,0 +1,43 @@
+package dnd.studyplanner;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.repository.QuestionBookRepository;
+import dnd.studyplanner.repository.QuestionRepository;
+
+@Component
+public class DataUtil {
+
+	@Autowired
+	QuestionRepository questionRepository;
+
+	@Autowired
+	QuestionBookRepository questionBookRepository;
+
+	public Question saveQuestionData() {
+		QuestionBook questionBook = questionBookRepository.save(
+			QuestionBook.builder().build()
+		);
+
+		Question question = questionRepository.save(
+			Question.builder()
+				.questionBook(questionBook)
+				.build()
+		);
+
+		return question;
+	}
+
+	public QuestionBook saveQuestionBookData() {
+		QuestionBook questionBook = questionBookRepository.save(
+			QuestionBook.builder().build()
+		);
+
+		return questionBook;
+	}
+}

--- a/src/test/java/dnd/studyplanner/DataUtil.java
+++ b/src/test/java/dnd/studyplanner/DataUtil.java
@@ -1,12 +1,19 @@
 package dnd.studyplanner;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.question.model.QuestionOptionType;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.option.request.OptionSaveDto;
+import dnd.studyplanner.dto.question.request.QuestionListDto;
 import dnd.studyplanner.repository.QuestionBookRepository;
 import dnd.studyplanner.repository.QuestionRepository;
 
@@ -39,5 +46,46 @@ public class DataUtil {
 		);
 
 		return questionBook;
+	}
+
+	public List<QuestionListDto> getQuestionListDto() {
+
+		List<QuestionListDto> requestDto = new ArrayList<>();
+
+		List<OptionSaveDto> optionsA = new ArrayList<>();
+		for (int i = 1; i < 4; i++) {
+			optionsA.add(OptionSaveDto.builder()
+				.optionContent("Test OptionA : " + i)
+				.optionImageEnable(false)
+				.optionImageUrl("").build());
+		}
+
+		List<OptionSaveDto> optionsB = new ArrayList<>();
+		for (int i = 1; i < 5; i++) {
+			optionsB.add(OptionSaveDto.builder()
+				.optionContent("Test OptionB : " + i)
+				.optionImageEnable(true)
+				.optionImageUrl("testImg.com/" + i).build());
+		}
+
+		requestDto.add(
+			QuestionListDto.builder()
+				.questionContent("Test Question A")
+				.questionOptionType(QuestionOptionType.TEXT)
+				.questionAnswer(3)
+				.optionSaveDtoList(optionsA)
+				.build()
+		);
+
+		requestDto.add(
+			QuestionListDto.builder()
+				.questionContent("Test Question B")
+				.questionOptionType(QuestionOptionType.IMAGE)
+				.questionAnswer(3)
+				.optionSaveDtoList(optionsB)
+				.build()
+		);
+
+		return requestDto;
 	}
 }

--- a/src/test/java/dnd/studyplanner/service/OptionServiceTest.java
+++ b/src/test/java/dnd/studyplanner/service/OptionServiceTest.java
@@ -1,0 +1,79 @@
+package dnd.studyplanner.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import dnd.studyplanner.DataUtil;
+import dnd.studyplanner.domain.option.model.Option;
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.option.request.OptionListSaveDto;
+import dnd.studyplanner.dto.option.request.OptionSaveDto;
+import dnd.studyplanner.exception.BaseException;
+import dnd.studyplanner.repository.OptionRepository;
+import dnd.studyplanner.repository.QuestionRepository;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class OptionServiceTest {
+
+	@Autowired
+	QuestionRepository questionRepository;
+
+	@Autowired
+	OptionRepository optionRepository;
+
+	@Autowired
+	OptionService optionService;
+
+	@Autowired
+	DataUtil dataUtil;
+
+	@Transactional
+	@DisplayName(value = "Option 리스트로 저장")
+	@Test
+	public void optionSaveAsListTest() throws BaseException {
+		//given
+		Question question = dataUtil.saveQuestionData();
+		int optionsCnt = 4;
+
+		List<OptionSaveDto> optionSaveDtoList = new ArrayList<>();
+		for (int i = 0; i < optionsCnt; i++) {
+			optionSaveDtoList.add(
+				OptionSaveDto.builder()
+					.optionContent("Test Content" + i)
+					.optionImageEnable(false)
+					.optionImageUrl("")
+					.build()
+			);
+		}
+
+		OptionListSaveDto optionListSaveDto = OptionListSaveDto.builder()
+			.questionId(question.getId())
+			.options(optionSaveDtoList)
+			.build();
+
+		//when
+		optionService.saveOptions(optionListSaveDto);
+		List<Option> options = optionRepository.findOptionsByQuestion_Id(question.getId());
+
+		//then
+		assertThat(question.getOptions().size()).isEqualTo(optionsCnt);
+		assertThat(options.size()).isEqualTo(optionsCnt);
+
+		assertThat(options.get(0).getOptionContent()).isEqualTo("Test Content" + 0);
+		assertThat(options.get(1).getOptionContent()).isEqualTo("Test Content" + 1);
+
+	}
+
+}

--- a/src/test/java/dnd/studyplanner/service/QuestionBookServiceTest.java
+++ b/src/test/java/dnd/studyplanner/service/QuestionBookServiceTest.java
@@ -1,0 +1,90 @@
+package dnd.studyplanner.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import dnd.studyplanner.DataUtil;
+import dnd.studyplanner.domain.option.model.Option;
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.option.request.OptionSaveDto;
+import dnd.studyplanner.dto.question.request.QuestionListDto;
+import dnd.studyplanner.repository.OptionRepository;
+import dnd.studyplanner.repository.QuestionRepository;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class QuestionBookServiceTest {
+
+	@Autowired
+	DataUtil dataUtil;
+
+	@Autowired
+	QuestionRepository questionRepository;
+
+	@Autowired
+	OptionRepository optionRepository;
+
+	@Test
+	public void saveQuestionsTest() {
+	    //given
+		QuestionBook questionBook = dataUtil.saveQuestionBookData();
+		List<QuestionListDto> questionListDto = dataUtil.getQuestionListDto();
+
+		//when
+		List<Question> questions = new ArrayList<>();
+
+		// MutiValueMap으로 Question-Options 저장
+		MultiValueMap<Question, OptionSaveDto> optionBuffer = new LinkedMultiValueMap<>();
+
+		for (QuestionListDto listDto : questionListDto) { // 여러 문제(Question)을 순회하면서
+			Question entity = listDto.toEntity(questionBook);
+
+			questions.add(entity);
+
+			// 하나의 Question에 저장되어있는 Option들을 MutiValueMap에 저장
+			List<OptionSaveDto> optionSaveDtoList = listDto.getOptionSaveDtoList();
+			for (OptionSaveDto optionSaveDto : optionSaveDtoList) {
+				optionBuffer.add(entity, optionSaveDto);
+			}
+		}
+
+		questionRepository.saveAll(questions); // 문제 List 저장
+
+		List<Option> options = new ArrayList<>(); // saveAll 할 option 리스트 초기화
+
+		// MutivalueMap에 저장되어있던 객체(Question)를 통해 DB조회 없이 관계를 찾을 수 있음
+		for (Question question : optionBuffer.keySet()) {
+			for (OptionSaveDto optionSaveDto : optionBuffer.get(question)) {
+				options.add(
+					optionSaveDto.toEntity(question)
+				);
+			}
+		} // N * M 연산이 이루어짐...
+
+		optionRepository.saveAll(options);
+
+	    //then
+		List<Question> allQuestions = questionRepository.findAll();
+		List<Option> allOptions = optionRepository.findAll();
+
+		assertThat(allQuestions.size()).isEqualTo(2);
+
+		// Test Question A : 3, B : 4개의 Option을 가짐
+		assertThat(allOptions.size()).isEqualTo(7);
+	}
+
+}

--- a/src/test/java/dnd/studyplanner/service/QuestionServiceTest.java
+++ b/src/test/java/dnd/studyplanner/service/QuestionServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import dnd.studyplanner.DataUtil;
 import dnd.studyplanner.domain.question.model.Question;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 import dnd.studyplanner.dto.question.request.QuestionSaveDto;
@@ -30,14 +31,15 @@ class QuestionServiceTest {
 	@Autowired
 	QuestionBookRepository questionBookRepository;
 
+	@Autowired
+	DataUtil dataUtil;
+
 	@Transactional
 	@DisplayName(value = "문제 저장 테스트")
 	@Test
 	public void saveQuestionTest() throws BaseException {
 		//given
-		QuestionBook questionBook = questionBookRepository.save(
-			QuestionBook.builder().build()
-		);
+		QuestionBook questionBook = dataUtil.saveQuestionBookData();
 
 		QuestionSaveDto saveDto = QuestionSaveDto.builder()
 			.questionAnswer(3)
@@ -56,7 +58,7 @@ class QuestionServiceTest {
 	}
 
 	@Transactional
-	@DisplayName(value = "존재하지 않는 문제집에 저장하는 경우")
+	@DisplayName(value = "문제집 예외 테스트")
 	@Test
 	public void saveAtNoQuestionBookTest() throws BaseException {
 		//given

--- a/src/test/java/dnd/studyplanner/service/QuestionServiceTest.java
+++ b/src/test/java/dnd/studyplanner/service/QuestionServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import dnd.studyplanner.DataUtil;
 import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.question.model.QuestionOptionType;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 import dnd.studyplanner.dto.question.request.QuestionSaveDto;
 import dnd.studyplanner.exception.BaseException;
@@ -44,7 +45,7 @@ class QuestionServiceTest {
 		QuestionSaveDto saveDto = QuestionSaveDto.builder()
 			.questionAnswer(3)
 			.questionContent("고양이는 귀엽나요?")
-			.questionOptionType("Image")
+			.questionOptionType(QuestionOptionType.IMAGE)
 			.questionBookId(questionBook.getId())
 			.build();
 
@@ -65,7 +66,7 @@ class QuestionServiceTest {
 		QuestionSaveDto saveDto = QuestionSaveDto.builder()
 			.questionAnswer(3)
 			.questionContent("고양이는 귀엽나요?")
-			.questionOptionType("Image")
+			.questionOptionType(QuestionOptionType.IMAGE)
 			.questionBookId(-1L) // 존재할 수 없는 문제집 Id
 			.build();
 

--- a/src/test/java/dnd/studyplanner/service/QuestionServiceTest.java
+++ b/src/test/java/dnd/studyplanner/service/QuestionServiceTest.java
@@ -1,0 +1,76 @@
+package dnd.studyplanner.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.question.request.QuestionSaveDto;
+import dnd.studyplanner.exception.BaseException;
+import dnd.studyplanner.repository.QuestionBookRepository;
+import dnd.studyplanner.repository.QuestionRepository;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class QuestionServiceTest {
+
+	@Autowired
+	QuestionService questionService;
+
+	@Autowired
+	QuestionRepository questionRepository;
+
+	@Autowired
+	QuestionBookRepository questionBookRepository;
+
+	@Transactional
+	@DisplayName(value = "문제 저장 테스트")
+	@Test
+	public void saveQuestionTest() throws BaseException {
+		//given
+		QuestionBook questionBook = questionBookRepository.save(
+			QuestionBook.builder().build()
+		);
+
+		QuestionSaveDto saveDto = QuestionSaveDto.builder()
+			.questionAnswer(3)
+			.questionContent("고양이는 귀엽나요?")
+			.questionOptionType("Image")
+			.questionBookId(questionBook.getId())
+			.build();
+
+		System.out.println("questionBook = " + questionBook.getId());
+		//when
+		Question saveQuestion = questionService.saveQuestion(saveDto);
+		//then
+		assertThat(saveQuestion.getQuestionBook().getId()).isEqualTo(questionBook.getId());
+		assertThat(questionBook.getQuestions().get(0).getQuestionContent())
+			.isEqualTo("고양이는 귀엽나요?");
+	}
+
+	@Transactional
+	@DisplayName(value = "존재하지 않는 문제집에 저장하는 경우")
+	@Test
+	public void saveAtNoQuestionBookTest() throws BaseException {
+		//given
+		QuestionSaveDto saveDto = QuestionSaveDto.builder()
+			.questionAnswer(3)
+			.questionContent("고양이는 귀엽나요?")
+			.questionOptionType("Image")
+			.questionBookId(-1L) // 존재할 수 없는 문제집 Id
+			.build();
+
+		//then
+		assertThatThrownBy(() -> {
+			questionService.saveQuestion(saveDto);
+		}).isInstanceOf(BaseException.class);
+	}
+
+}


### PR DESCRIPTION
우선 섬세한 리뷰 감사합니다..!
제시해주신 방안 두개 중에서 2안으로 만들어보았습니다.

MultiValueMap을 활용해서 2안 과정 중에
- `[옵션 전체 리스트] 의 [개별 옵션 리스트]` 구조를 대체해서
- `[문제 리스트]를 saveAll() 했을 때 -> question ID 목록을 리턴 받아서` 를 줄일 수 있었어요.

우려하신대로 결과적으론 N * M 의 연산이 수행되긴 합니다. (N : Question 수, M : Options 수)
근데, 1안에서도 똑같은것 같아요. Question의 Id 값을 어찌어찌 알아내도, Options 하나하나에 매핑해야 하니깐요..?

QuestionBookServiceTest.class 확인하시면 전체 과정 보실 수 있을 겁니다!
급하게 시험해보느라 Service 로직에는 아직 만들어두진 않았어요. 요청을 List로 받기 위해 Dto가 조금 변경되었습니다!

확인해보시구 괜찮으시면 이 방안으로 QuestionBook 단위로 요청받는 방향으로 개선해볼게요!

