### PR TITLE
Feature/questionbook solve contains(Fix/post api)

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/GoalController.java
+++ b/src/main/java/dnd/studyplanner/controller/GoalController.java
@@ -1,0 +1,31 @@
+package dnd.studyplanner.controller;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.dto.goal.request.GoalSaveDto;
+import dnd.studyplanner.dto.response.CustomResponse;
+import dnd.studyplanner.service.IGoalService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static dnd.studyplanner.dto.response.CustomResponseStatus.SAVE_GOAL_SUCCESS;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/goal")
+@RestController
+public class GoalController {
+
+    private final IGoalService goalService;
+
+    @PostMapping("/save")
+    public ResponseEntity<CustomResponse> addPeriodGoal(
+            @RequestHeader(value = "Access-Token") String accessToken,
+            @RequestBody GoalSaveDto goalSaveDto) {
+
+        Goal updateGoal = goalService.addPeriodGoal(accessToken, goalSaveDto);
+
+        return new CustomResponse<>(updateGoal, SAVE_GOAL_SUCCESS).toResponseEntity();
+    }
+}

--- a/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
@@ -33,9 +33,13 @@ public class QuestionBookController {
 	private final IUserRateService userGoalRateService;
 
 	@PostMapping("/list")
-	public ResponseEntity<CustomResponse> addQuestionBookAsList(@RequestBody QuestionBookDto saveDto) {
+	public ResponseEntity<CustomResponse> addQuestionBookAsList(
+		@RequestHeader String accessToken,
+		@RequestBody QuestionBookDto saveDto
+	) {
 
 		List<String> questionList = questionBookService.saveQuestionBook(saveDto);
+		userGoalRateService.updatePostQuestionBook(accessToken, saveDto.getGoalId());
 
 		return new CustomResponse<>(questionList, SAVE_QUESTION_BOOK_SUCCESS).toResponseEntity();
 	}

--- a/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
+import dnd.studyplanner.dto.questionbook.request.SolveQuestionBookDto;
+import dnd.studyplanner.dto.questionbook.response.QuestionBookSolveResponse;
 import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
 import dnd.studyplanner.dto.response.CustomResponse;
 import dnd.studyplanner.service.IQuestionBookService;
@@ -43,5 +45,32 @@ public class QuestionBookController {
 		return new CustomResponse<>(response).toResponseEntity();
 	}
 
+	@PostMapping("/end")
+	public ResponseEntity<CustomResponse> finishQuestionBook(
+		@RequestHeader("Access-Token") String accessToken,
+		@RequestBody SolveQuestionBookDto requestDto
+	) {
+		boolean passQuestionBook = questionBookService.isPassQuestionBook(accessToken, requestDto);
+		if (!passQuestionBook) {
+			QuestionBookSolveResponse response = QuestionBookSolveResponse.builder()
+				.isPass(false)
+				.addedRate()
+				.questionBookPostRate()
+				.questionBookSolveRate()
+				.build();
+			return new CustomResponse<>(response).toResponseEntity();
+		}
+
+		QuestionBookSolveResponse response = QuestionBookSolveResponse.builder()
+			.isPass(true)
+			.addedRate()
+			.questionBookPostRate()
+			.questionBookSolveRate()
+			.build();
+
+		goalUserService.updateUserGoalRate();
+
+		return new CustomResponse<>(response).toResponseEntity();
+	}
 
 }

--- a/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
@@ -5,12 +5,15 @@ import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
+import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
 import dnd.studyplanner.dto.response.CustomResponse;
 import dnd.studyplanner.service.IQuestionBookService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +33,14 @@ public class QuestionBookController {
 		List<String> questionList = questionBookService.saveQuestionBook(saveDto);
 
 		return new CustomResponse<>(questionList, SAVE_QUESTION_BOOK_SUCCESS).toResponseEntity();
+	}
+
+	@GetMapping("/list/live")
+	public ResponseEntity<CustomResponse> getAllUserQuestionBook(
+		@RequestHeader("Access-Token") String accessToken
+	) {
+		List<UserQuestionBookResponse> response = questionBookService.getAllUserQuestionBooks(accessToken);
+		return new CustomResponse<>(response).toResponseEntity();
 	}
 
 

--- a/src/main/java/dnd/studyplanner/controller/QuestionController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionController.java
@@ -1,5 +1,7 @@
 package dnd.studyplanner.controller;
 
+import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,12 +33,15 @@ public class QuestionController {
 	@PostMapping("/solve")
 	public ResponseEntity<CustomResponse> checkIsAnswer(
 		@RequestHeader("Access-Token") String accessToken,
-		@RequestBody QuestionSolveDto solveDto) throws BaseException {
+		@RequestBody QuestionSolveDto solveDto) {
 		log.debug("[RequestHeader] : {}", accessToken);
 
-
-		boolean isCorrectAnswer = questionService.solveQuestion(solveDto, accessToken);
-
-		return new CustomResponse<>(isCorrectAnswer).toResponseEntity();
+		try {
+			boolean isCorrectAnswer = questionService.solveQuestion(solveDto, accessToken);
+			return new CustomResponse<>(isCorrectAnswer).toResponseEntity();
+		} catch (BaseException e) {
+			return new CustomResponse<>(NOT_EXIST_DATA).toResponseEntity();
+		}
 	}
+
 }

--- a/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
+++ b/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
@@ -1,14 +1,19 @@
 package dnd.studyplanner.controller;
 
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.UserJoinGroup;
 import dnd.studyplanner.dto.response.CustomResponse;
+import dnd.studyplanner.dto.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
+import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 import dnd.studyplanner.service.IStudyGroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static dnd.studyplanner.dto.response.CustomResponseStatus.SAVE_GROUP_SUCCESS;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/group")
@@ -17,13 +22,13 @@ public class StudyGroupController {
 
     private final IStudyGroupService studyGroupService;
 
-    // 그룹 생성
+    // 그룹 생성 & 사용자 초대
     @PostMapping("/info")
     public ResponseEntity<CustomResponse> addStudyGroup(
             @RequestHeader(value = "Access-Token") String accessToken,
-            @RequestBody StudyGroupSaveDto studyGroupSaveDto) {
+            @RequestBody StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto) {
 
-        StudyGroup updateStudyGroup = studyGroupService.saveStudyGroup(studyGroupSaveDto, accessToken);
+        StudyGroupSaveResponse updateStudyGroup = studyGroupService.saveGroupAndInvite(studyGroupSaveDto, userJoinGroupSaveDto, accessToken);
 
         return new CustomResponse<>(updateStudyGroup, SAVE_GROUP_SUCCESS).toResponseEntity();
 

--- a/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
+++ b/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
@@ -1,9 +1,7 @@
 package dnd.studyplanner.controller;
 
-import dnd.studyplanner.domain.studygroup.model.StudyGroup;
-import dnd.studyplanner.domain.user.model.UserJoinGroup;
 import dnd.studyplanner.dto.response.CustomResponse;
-import dnd.studyplanner.dto.response.StudyGroupSaveResponse;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 import dnd.studyplanner.service.IStudyGroupService;
@@ -12,8 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static dnd.studyplanner.dto.response.CustomResponseStatus.SAVE_GROUP_SUCCESS;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/group")

--- a/src/main/java/dnd/studyplanner/domain/base/BaseEntity.java
+++ b/src/main/java/dnd/studyplanner/domain/base/BaseEntity.java
@@ -1,6 +1,7 @@
 package dnd.studyplanner.domain.base;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -17,8 +18,8 @@ import lombok.Getter;
 public class BaseEntity {
 
 	@CreatedDate
-	private LocalDate createdDate;
+	private LocalDateTime createdDate;
 
 	@LastModifiedDate
-	private LocalDate modifiedDate;
+	private LocalDateTime modifiedDate;
 }

--- a/src/main/java/dnd/studyplanner/domain/goal/model/Goal.java
+++ b/src/main/java/dnd/studyplanner/domain/goal/model/Goal.java
@@ -1,5 +1,6 @@
 package dnd.studyplanner.domain.goal.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,9 +21,13 @@ import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 import dnd.studyplanner.domain.user.model.User;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @Entity
 public class Goal extends BaseEntity {
 
@@ -36,8 +41,9 @@ public class Goal extends BaseEntity {
 	private StudyGroup studyGroup;
 
 	private String goalContent;
-	private LocalDateTime goalStartDate;
-	private LocalDateTime goalEndDate;
+
+	private LocalDate goalStartDate;
+	private LocalDate goalEndDate;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn
@@ -49,4 +55,22 @@ public class Goal extends BaseEntity {
 
 	@OneToMany(mappedBy = "questionBookGoal", cascade = CascadeType.ALL)
 	private List<QuestionBook> questionBooks = new ArrayList<>();
+
+	@Builder
+	public Goal(StudyGroup studyGroup, String goalContent, LocalDate goalStartDate, LocalDate goalEndDate,
+				User goalRegisterUser, User goalUpdateUser) {
+		this.studyGroup = studyGroup;
+		this.goalContent = goalContent;
+		this.goalStartDate = goalStartDate;
+		this.goalEndDate = goalEndDate;
+		this.goalRegisterUser = goalRegisterUser;
+		this.goalUpdateUser = goalUpdateUser;
+	}
+
+	public void update(String goalContent, LocalDate goalStartDate, LocalDate goalEndDate, User goalUpdateUser) {
+		this.goalContent = goalContent;
+		this.goalStartDate = goalStartDate;
+		this.goalEndDate = goalEndDate;
+		this.goalUpdateUser = goalUpdateUser;
+	}
 }

--- a/src/main/java/dnd/studyplanner/domain/goal/model/Goal.java
+++ b/src/main/java/dnd/studyplanner/domain/goal/model/Goal.java
@@ -45,6 +45,10 @@ public class Goal extends BaseEntity {
 	private LocalDate goalStartDate;
 	private LocalDate goalEndDate;
 
+	private int minAnswerPerQuestionBook;
+	private int minQuestionPerQuestionBook;
+	private int minSolveQuestionBook;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn
 	private User goalRegisterUser;

--- a/src/main/java/dnd/studyplanner/domain/questionbook/model/QuestionBook.java
+++ b/src/main/java/dnd/studyplanner/domain/questionbook/model/QuestionBook.java
@@ -46,7 +46,6 @@ public class QuestionBook extends BaseEntity {
 	private User questionBookCreateUser;
 
 	private String questionBookName;
-	private int questionBookMinAchieveRate;
 	private int questionBookQuestionNum;
 
 	@OneToMany(mappedBy = "questionBook", cascade = CascadeType.ALL)
@@ -60,11 +59,10 @@ public class QuestionBook extends BaseEntity {
 
 	@Builder
 	public QuestionBook(Goal questionBookGoal, User questionBookCreateUser, String questionBookName,
-		int questionBookMinAchieveRate, int questionBookQuestionNum) {
+		int questionBookQuestionNum) {
 		this.questionBookGoal = questionBookGoal;
 		this.questionBookCreateUser = questionBookCreateUser;
 		this.questionBookName = questionBookName;
-		this.questionBookMinAchieveRate = questionBookMinAchieveRate;
 		this.questionBookQuestionNum = questionBookQuestionNum;
 
 		questionBookGoal.getQuestionBooks().add(this);

--- a/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroup.java
+++ b/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroup.java
@@ -54,8 +54,7 @@ public class StudyGroup extends BaseEntity {
 
 	@Builder
 	public StudyGroup(String groupName, User groupCreateUser, LocalDate groupStartDate, LocalDate groupEndDate,
-					  String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
-
+		String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
 		this.groupName = groupName;
 		this.groupCreateUser = groupCreateUser;
 		this.groupStartDate = groupStartDate;
@@ -64,11 +63,10 @@ public class StudyGroup extends BaseEntity {
 		this.groupImageUrl = groupImageUrl;
 		this.groupCategory = groupCategory;
 		this.groupStatus = groupStatus;
-
 	}
 
 	public void update(String groupName, User groupCreateUser, LocalDate groupStartDate, LocalDate groupEndDate,
-					   String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
+		String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
 
 		this.groupName = groupName;
 		this.groupCreateUser = groupCreateUser;
@@ -80,5 +78,4 @@ public class StudyGroup extends BaseEntity {
 		this.groupStatus = groupStatus;
 
 	}
-
 }

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserGoalRate.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserGoalRate.java
@@ -59,6 +59,12 @@ public class UserGoalRate {
 		checkFinishGoal();
 	}
 
+	public void updatePostQuestionBook() {
+		achieveRate += 50;
+		postRate += 50;
+		checkFinishGoal();
+	}
+
 	private void checkFinishGoal() {
 		if (this.achieveRate >= 100) {
 			isFinishGoal = true;

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserGoalRate.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserGoalRate.java
@@ -1,0 +1,68 @@
+package dnd.studyplanner.domain.user.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGoalRate {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_goal_rate_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "goal_id")
+	private Goal goal;
+
+	private int achieveRate;
+	private int postRate;
+	private int solveRate;
+
+	private boolean isFinishGoal;
+
+	@Builder
+	public UserGoalRate(User user, Goal goal) {
+		this.user = user;
+		this.goal = goal;
+		this.achieveRate = 0;
+		this.postRate = 0;
+		this.solveRate = 0;
+		this.isFinishGoal = false;
+	}
+
+	public void updateQuestionBookSolve(int addRate) {
+		if (this.isFinishGoal) {
+			return;
+		}
+
+		achieveRate += addRate;
+		solveRate += addRate;
+		checkFinishGoal();
+	}
+
+	private void checkFinishGoal() {
+		if (this.achieveRate >= 100) {
+			isFinishGoal = true;
+			achieveRate = 100;
+		}
+	}
+}

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserJoinGroup.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserJoinGroup.java
@@ -13,10 +13,13 @@ import javax.persistence.ManyToOne;
 
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class UserJoinGroup extends BaseEntity {
 

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserJoinGroup.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserJoinGroup.java
@@ -13,6 +13,7 @@ import javax.persistence.ManyToOne;
 
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -32,5 +33,13 @@ public class UserJoinGroup extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "study_group_id")
 	private StudyGroup studyGroup;
+
+	@Builder
+	public UserJoinGroup(User user, StudyGroup studyGroup) {
+		this.user = user;
+		this.studyGroup = studyGroup;
+
+		user.getUserJoinGroups().add(this);
+	}
 
 }

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestionBook.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestionBook.java
@@ -13,6 +13,7 @@ import javax.persistence.ManyToOne;
 
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -32,6 +33,18 @@ public class UserSolveQuestionBook extends BaseEntity {
 	@JoinColumn(name = "question_book_id")
 	private QuestionBook solveQuestionBook;
 
+	private boolean isSolved;
+
+	private boolean isPassed;
+	private int questionNumber;
 	private int answerNum;
-	private int answerRate;
+
+	@Builder
+	public UserSolveQuestionBook(User solveUser, QuestionBook solveQuestionBook, int questionNumber) {
+		this.solveUser = solveUser;
+		this.solveQuestionBook = solveQuestionBook;
+		this.questionNumber = questionNumber;
+		this.isSolved = false;
+		this.isPassed = false;
+	}
 }

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestionBook.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestionBook.java
@@ -13,10 +13,14 @@ import javax.persistence.ManyToOne;
 
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class UserSolveQuestionBook extends BaseEntity {
 

--- a/src/main/java/dnd/studyplanner/dto/goal/request/GoalSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/goal/request/GoalSaveDto.java
@@ -1,0 +1,34 @@
+package dnd.studyplanner.dto.goal.request;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoalSaveDto {
+
+    private Long studyGroupId;
+    private String goalContent;
+    private LocalDate goalStartDate;
+    private LocalDate goalEndDate;
+    private Long goalRegisterUserId;
+    private Long goalUpdateUserId;
+
+    public Goal toEntity(User user, StudyGroup studyGroup) {
+        return Goal.builder()
+                .studyGroup(studyGroup)
+                .goalContent(this.goalContent)
+                .goalStartDate(this.goalStartDate)
+                .goalEndDate(this.goalEndDate)
+                .goalRegisterUser(user)
+                .goalUpdateUser(user)
+                .build();
+    }
+
+}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookDto.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookDto.java
@@ -18,21 +18,16 @@ import lombok.NoArgsConstructor;
 public class QuestionBookDto {
 
 	private Long goalId;
-	private Long createUserId;
 	private String questionBookName;
-	private int questionBookMinAchieveRate;
-	private int questionBookQuestionNum;
 
 	private List<QuestionListDto> questionDtoList = new ArrayList<>();
 
+
+
 	@Builder
-	public QuestionBookDto(Long goalId, Long createUserId, String questionBookName, int questionBookMinAchieveRate,
-		int questionBookQuestionNum, List<QuestionListDto> questionDtoList) {
+	public QuestionBookDto(Long goalId, String questionBookName, List<QuestionListDto> questionDtoList) {
 		this.goalId = goalId;
-		this.createUserId = createUserId;
 		this.questionBookName = questionBookName;
-		this.questionBookMinAchieveRate = questionBookMinAchieveRate;
-		this.questionBookQuestionNum = questionBookQuestionNum;
 		this.questionDtoList = questionDtoList;
 	}
 
@@ -41,8 +36,6 @@ public class QuestionBookDto {
 			.questionBookGoal(goal)
 			.questionBookCreateUser(user)
 			.questionBookName(this.questionBookName)
-			.questionBookQuestionNum(this.questionBookQuestionNum)
-			.questionBookMinAchieveRate(this.questionBookMinAchieveRate)
 			.build();
 	}
 

--- a/src/main/java/dnd/studyplanner/dto/questionbook/request/SolveQuestionBookDto.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/request/SolveQuestionBookDto.java
@@ -1,0 +1,11 @@
+package dnd.studyplanner.dto.questionbook.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SolveQuestionBookDto {
+	private Long questionBookId;
+}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/response/QuestionBookSaveResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/response/QuestionBookSaveResponse.java
@@ -1,0 +1,24 @@
+package dnd.studyplanner.dto.questionbook.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionBookSaveResponse {
+	private int addedRate; // 추가된 달성률
+	private int userTotalRate; // 사용자의 전체 달성률
+	private int questionBookPostRate;
+	private int questionBookSolveRate;
+
+	@Builder
+	public QuestionBookSaveResponse(int addedRate, int userTotalRate, int questionBookPostRate,
+		int questionBookSolveRate) {
+		this.addedRate = addedRate;
+		this.userTotalRate = userTotalRate;
+		this.questionBookPostRate = questionBookPostRate;
+		this.questionBookSolveRate = questionBookSolveRate;
+	}
+}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/response/QuestionBookSolveResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/response/QuestionBookSolveResponse.java
@@ -1,0 +1,26 @@
+package dnd.studyplanner.dto.questionbook.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionBookSolveResponse {
+	private boolean isPass;
+	private int addedRate; // 추가된 달성률
+	private int userTotalRate; // 사용자의 전체 달성률
+	private int questionBookPostRate; // 출제를 통해 얻은 달성률 (0% or 50%)
+	private int questionBookSolveRate; // 풀이를 통해 얻은 달성률 (0% ~ 50%)
+
+	@Builder
+	public QuestionBookSolveResponse(boolean isPass, int addedRate, int userTotalRate, int questionBookPostRate,
+		int questionBookSolveRate) {
+		this.isPass = isPass;
+		this.addedRate = addedRate;
+		this.userTotalRate = userTotalRate;
+		this.questionBookPostRate = questionBookPostRate;
+		this.questionBookSolveRate = questionBookSolveRate;
+	}
+}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/response/UserQuestionBookResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/response/UserQuestionBookResponse.java
@@ -1,0 +1,37 @@
+package dnd.studyplanner.dto.questionbook.response;
+
+import java.time.LocalDateTime;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.question.model.Question;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.domain.user.model.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserQuestionBookResponse {
+
+	private Long questionBookId;
+	private String goalContent;
+	private String userNickName;
+	private String userProfileImageUrl;
+	private String studyGroupName;
+	private boolean isSolved;
+
+	private LocalDateTime questionCreatedAt;
+
+	@Builder
+	public UserQuestionBookResponse(User user, QuestionBook questionBook, boolean isSolved) {
+		this.questionBookId = questionBook.getId();
+		this.goalContent = questionBook.getQuestionBookGoal().getGoalContent();
+		this.userNickName = user.getUserNickName();
+		this.userProfileImageUrl = user.getUserProfileImageUrl();
+		this.studyGroupName = questionBook.getQuestionBookGoal().getStudyGroup().getGroupName();
+		this.questionCreatedAt = questionBook.getCreatedDate();
+		this.isSolved = isSolved;
+	}
+}

--- a/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
+++ b/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
@@ -21,7 +21,9 @@ public enum CustomResponseStatus {
 	TOKEN_INVALID(false, 4001, "유효하지 않은 토큰입니다", HttpStatus.CONFLICT),
 	TOKEN_EXPIRED(false, 4002, "만료된 토큰입니다", HttpStatus.UNAUTHORIZED),
 	NOT_VALID_USER(false, 4003, "유효하지 않는 이메일 형식입니다", HttpStatus.BAD_REQUEST),
-	NOT_EXIST_USER(false, 4004, "존재하지 않는 사용자입니다", HttpStatus.NOT_FOUND);
+	NOT_EXIST_USER(false, 4004, "존재하지 않는 사용자입니다", HttpStatus.NOT_FOUND),
+
+	NOT_EXIST_DATA(false, 4100, "존재하지 않는 데이터입니다.", HttpStatus.BAD_REQUEST);
 
 
 	private final boolean isSuccess;

--- a/src/main/java/dnd/studyplanner/dto/response/StudyGroupSaveResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/response/StudyGroupSaveResponse.java
@@ -1,0 +1,24 @@
+package dnd.studyplanner.dto.response;
+
+
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StudyGroupSaveResponse {
+
+    private StudyGroup newStudyGroup;
+
+    private List<String> studyGroupMember;
+
+    @Builder
+    public StudyGroupSaveResponse(StudyGroup newStudyGroup, List<String> studyGroupMember) {
+        this.newStudyGroup = newStudyGroup;
+        this.studyGroupMember = studyGroupMember;
+    }
+}

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/request/StudyGroupSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/request/StudyGroupSaveDto.java
@@ -1,6 +1,7 @@
 package dnd.studyplanner.dto.studyGroup.request;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
@@ -26,6 +27,8 @@ public class StudyGroupSaveDto {
 
 	@Setter
 	private StudyGroupStatus groupStatus;
+
+	List<String> invitedUserEmailList;
 
 	@Builder
 	public StudyGroupSaveDto(Long createUserId, String groupName, LocalDate groupStartDate, LocalDate groupEndDate,

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/response/StudyGroupSaveResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/response/StudyGroupSaveResponse.java
@@ -1,4 +1,4 @@
-package dnd.studyplanner.dto.response;
+package dnd.studyplanner.dto.studyGroup.response;
 
 
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;

--- a/src/main/java/dnd/studyplanner/dto/userJoinGroup/request/UserJoinGroupSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/userJoinGroup/request/UserJoinGroupSaveDto.java
@@ -1,0 +1,20 @@
+package dnd.studyplanner.dto.userJoinGroup.request;
+
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.domain.user.model.UserJoinGroup;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserJoinGroupSaveDto {
+
+	public UserJoinGroup toEntity(User user, StudyGroup studyGroup) {
+		return UserJoinGroup.builder()
+			.user(user)
+			.studyGroup(studyGroup)
+			.build();
+	}
+}

--- a/src/main/java/dnd/studyplanner/repository/UserGoalRateRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserGoalRateRepository.java
@@ -1,0 +1,12 @@
+package dnd.studyplanner.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.UserGoalRate;
+
+public interface UserGoalRateRepository extends JpaRepository<UserGoalRate, Long> {
+	Optional<UserGoalRate> findByUser_IdAndGoal_Id(Long userId, Long goalId);
+}

--- a/src/main/java/dnd/studyplanner/repository/UserJoinGroupRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserJoinGroupRepository.java
@@ -1,0 +1,8 @@
+package dnd.studyplanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.studyplanner.domain.user.model.UserJoinGroup;
+
+public interface UserJoinGroupRepository extends JpaRepository<UserJoinGroup, Long> {
+}

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -1,13 +1,11 @@
 package dnd.studyplanner.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
 
 public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolveQuestionBook, Long> {
-	List<UserSolveQuestionBook> findAllBySolveUser_Id(Long id);
+	List<UserSolveQuestionBook> findAllBySolveUser_IdOrderByCreatedDateDesc(Long id);
 }

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -1,0 +1,11 @@
+package dnd.studyplanner.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
+
+public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolveQuestionBook, Long> {
+}

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -1,5 +1,6 @@
 package dnd.studyplanner.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
 
 public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolveQuestionBook, Long> {
+	List<UserSolveQuestionBook> findAllBySolveUser_Id(Long id);
 }

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionRepository.java
@@ -1,8 +1,11 @@
 package dnd.studyplanner.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
 
 public interface UserSolveQuestionRepository extends JpaRepository<UserSolveQuestion, Long> {
+	int countBySolveUser_IdAndAndSolveQuestionBook_IdAndRightCheck(Long userId, Long questionBookId, boolean right);
 }

--- a/src/main/java/dnd/studyplanner/service/IGoalService.java
+++ b/src/main/java/dnd/studyplanner/service/IGoalService.java
@@ -1,0 +1,9 @@
+package dnd.studyplanner.service;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.dto.goal.request.GoalSaveDto;
+
+public interface IGoalService {
+
+    Goal addPeriodGoal(String accessToken, GoalSaveDto goalSaveDto);
+}

--- a/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
@@ -3,8 +3,11 @@ package dnd.studyplanner.service;
 import java.util.List;
 
 import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
+import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
 
 public interface IQuestionBookService {
 
 	List<String> saveQuestionBook(QuestionBookDto saveDto);
+
+	List<UserQuestionBookResponse> getAllUserQuestionBooks(String accessToken);
 }

--- a/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
@@ -3,6 +3,7 @@ package dnd.studyplanner.service;
 import java.util.List;
 
 import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
+import dnd.studyplanner.dto.questionbook.request.SolveQuestionBookDto;
 import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
 
 public interface IQuestionBookService {
@@ -10,4 +11,6 @@ public interface IQuestionBookService {
 	List<String> saveQuestionBook(QuestionBookDto saveDto);
 
 	List<UserQuestionBookResponse> getAllUserQuestionBooks(String accessToken);
+
+	boolean isPassQuestionBook(String accessToken, SolveQuestionBookDto requestDto);
 }

--- a/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
@@ -8,7 +8,7 @@ import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
 
 public interface IQuestionBookService {
 
-	List<String> saveQuestionBook(QuestionBookDto saveDto);
+	List<String> saveQuestionBook(String accessToken, QuestionBookDto saveDto);
 
 	List<UserQuestionBookResponse> getAllUserQuestionBooks(String accessToken);
 

--- a/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
@@ -1,10 +1,6 @@
 package dnd.studyplanner.service;
 
-import java.util.List;
-
-import dnd.studyplanner.domain.studygroup.model.StudyGroup;
-import dnd.studyplanner.domain.user.model.UserJoinGroup;
-import dnd.studyplanner.dto.response.StudyGroupSaveResponse;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 

--- a/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
@@ -1,10 +1,15 @@
 package dnd.studyplanner.service;
 
+import java.util.List;
+
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.UserJoinGroup;
+import dnd.studyplanner.dto.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
+import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 
 public interface IStudyGroupService {
 
-	StudyGroup saveStudyGroup(StudyGroupSaveDto studyGroupSaveDto, String accessToken);
+	StudyGroupSaveResponse saveGroupAndInvite(StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto, String accessToken);
 
 }

--- a/src/main/java/dnd/studyplanner/service/IUserRateService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserRateService.java
@@ -1,0 +1,10 @@
+package dnd.studyplanner.service;
+
+import dnd.studyplanner.domain.user.model.UserGoalRate;
+
+public interface IUserRateService {
+
+	UserGoalRate updateAfterQuestionBook(String accessToken, Long questionId);
+
+	UserGoalRate getUserGoalRateByQuestionBookId(String accessToken, Long questionId);
+}

--- a/src/main/java/dnd/studyplanner/service/IUserRateService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserRateService.java
@@ -4,9 +4,9 @@ import dnd.studyplanner.domain.user.model.UserGoalRate;
 
 public interface IUserRateService {
 
-	UserGoalRate updateAfterQuestionBook(String accessToken, Long questionId);
+	UserGoalRate updateAfterQuestionBook(UserGoalRate userGoalRate);
 
 	UserGoalRate getUserGoalRateByQuestionBookId(String accessToken, Long questionId);
 
-	void updatePostQuestionBook(String accessToken, Long goalId);
+	UserGoalRate updatePostQuestionBook(String accessToken, Long goalId);
 }

--- a/src/main/java/dnd/studyplanner/service/IUserRateService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserRateService.java
@@ -7,4 +7,6 @@ public interface IUserRateService {
 	UserGoalRate updateAfterQuestionBook(String accessToken, Long questionId);
 
 	UserGoalRate getUserGoalRateByQuestionBookId(String accessToken, Long questionId);
+
+	void updatePostQuestionBook(String accessToken, Long goalId);
 }

--- a/src/main/java/dnd/studyplanner/service/Impl/GoalService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/GoalService.java
@@ -1,0 +1,54 @@
+package dnd.studyplanner.service.Impl;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.dto.goal.request.GoalSaveDto;
+import dnd.studyplanner.jwt.JwtService;
+import dnd.studyplanner.repository.GoalRepository;
+import dnd.studyplanner.repository.StudyGroupRepository;
+import dnd.studyplanner.repository.UserRepository;
+import dnd.studyplanner.service.IGoalService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GoalService implements IGoalService {
+
+    private final UserRepository userRepository;
+    private final StudyGroupRepository studyGroupRepository;
+    private final GoalRepository goalRepository;
+    private final JwtService jwtService;
+
+    @Override
+    public Goal addPeriodGoal(String accessToken, GoalSaveDto goalSaveDto) {
+
+        Long currentUserId = getCurrentUserId(accessToken);
+        User user = userRepository.findById(currentUserId).get();
+
+        Long myStudyGroupId = goalSaveDto.getStudyGroupId();
+        log.debug("[Group ID] : {}", myStudyGroupId);
+        Optional<StudyGroup> studyGroup = studyGroupRepository.findById(myStudyGroupId);
+
+//        StudyGroup studyGroup = studyGroupRepository.findById(myStudyGroupId).get();
+
+        Goal updateGoal = goalSaveDto.toEntity(user, studyGroup.get());
+        goalRepository.save(updateGoal);
+
+        return updateGoal;
+    }
+
+    private Long getCurrentUserId(String userAccessToken) {
+
+        Long currentUserId = jwtService.getUserId(userAccessToken);
+        return currentUserId;
+    }
+}

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -21,6 +21,8 @@ import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
 import dnd.studyplanner.dto.option.request.OptionSaveDto;
 import dnd.studyplanner.dto.question.request.QuestionListDto;
 import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
+import dnd.studyplanner.dto.questionbook.response.UserQuestionBookResponse;
+import dnd.studyplanner.jwt.JwtService;
 import dnd.studyplanner.repository.GoalRepository;
 import dnd.studyplanner.repository.QuestionBookRepository;
 import dnd.studyplanner.repository.UserRepository;
@@ -40,6 +42,7 @@ public class QuestionBookService implements IQuestionBookService {
 	private final IQuestionService questionService;
 
 	private final IOptionService optionService;
+	private final JwtService jwtService;
 
 	private final UserRepository userRepository;
 	private final GoalRepository goalRepository;
@@ -87,6 +90,23 @@ public class QuestionBookService implements IQuestionBookService {
 		saveUserQuestionBook(goal, questionBook);
 
 		return questionContentList;
+	}
+
+	@Override
+	public List<UserQuestionBookResponse> getAllUserQuestionBooks(String accessToken) {
+		Long userId = jwtService.getUserId(accessToken);
+		List<UserQuestionBookResponse> response = new LinkedList<>();
+
+		userSolveQuestionBookRepository.findAllBySolveUser_Id(userId)
+			.forEach(e -> response.add(
+				UserQuestionBookResponse.builder()
+					.user(e.getSolveUser())
+					.questionBook(e.getSolveQuestionBook())
+					.isSolved(e.isSolved())
+					.build()
+			));
+
+		return response;
 	}
 
 	/**

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -102,7 +102,7 @@ public class QuestionBookService implements IQuestionBookService {
 		Long userId = jwtService.getUserId(accessToken);
 		List<UserQuestionBookResponse> response = new LinkedList<>();
 
-		userSolveQuestionBookRepository.findAllBySolveUser_Id(userId)
+		userSolveQuestionBookRepository.findAllBySolveUser_IdOrderByCreatedDateDesc(userId)
 			.forEach(e -> response.add(
 				UserQuestionBookResponse.builder()
 					.user(e.getSolveUser())
@@ -126,6 +126,7 @@ public class QuestionBookService implements IQuestionBookService {
 		Optional<QuestionBook> questionBook = questionBookRepository.findById(questionBookId);
 		// Question Book이 포함된 목표의 최소 정답률과 비교
 		Goal goal = questionBook.get().getQuestionBookGoal();
+
 		// 문제집 Pass시 기존 달성률에 문제집의 비중을 더함.
 		if (answerCount >= goal.getMinAnswerCount()) {
 			return true;

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -52,19 +52,16 @@ public class QuestionBookService implements IQuestionBookService {
 	private final UserSolveQuestionRepository userSolveQuestionRepository;
 	private final UserSolveQuestionBookRepository userSolveQuestionBookRepository;
 
-	public List<String> saveQuestionBook(QuestionBookDto saveDto) {
-		List<String> questionContentList = new ArrayList<>();
+	public List<String> saveQuestionBook(String accessToken, QuestionBookDto saveDto) {
+		Long userId = jwtService.getUserId(accessToken);
 
-		// for Test
-		// ID가 1인 entity 고정
-		// User user = userRepository.save(new User());
-		User user = userRepository.findById(1L).get();
-		Goal goal = goalRepository.save(new Goal());
-		// 추후 User, Goal Service에 의존하여 Id에 해당하는 Entity를 가져와야함
+		User user = userRepository.findById(userId).get();
+		Goal goal = goalRepository.findById(saveDto.getGoalId()).get();
 
 		QuestionBook entity = saveDto.toEntity(goal, user);
 		QuestionBook questionBook = questionBookRepository.save(entity);
 
+		List<String> questionContentList = new ArrayList<>();
 		MultiValueMap<Question, OptionSaveDto> optionBuffer = new LinkedMultiValueMap<>();
 
 		List<Option> options = new LinkedList<>();
@@ -128,7 +125,7 @@ public class QuestionBookService implements IQuestionBookService {
 		Goal goal = questionBook.get().getQuestionBookGoal();
 
 		// 문제집 Pass시 기존 달성률에 문제집의 비중을 더함.
-		if (answerCount >= goal.getMinAnswerCount()) {
+		if (answerCount >= goal.getMinAnswerPerQuestionBook()) {
 			return true;
 		}
 		return false;

--- a/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
@@ -8,7 +8,7 @@ import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 import dnd.studyplanner.jwt.JwtService;
 import dnd.studyplanner.repository.StudyGroupRepository;
-// import dnd.studyplanner.repository.UserJoinGroupRepository;
+import dnd.studyplanner.repository.UserJoinGroupRepository;
 import dnd.studyplanner.repository.UserRepository;
 import dnd.studyplanner.service.IStudyGroupService;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ public class StudyGroupService implements IStudyGroupService {
 
 	private final UserRepository userRepository;
 	private final StudyGroupRepository studyGroupRepository;
-	// private final UserJoinGroupRepository userJoinGroupRepository;
+	private final UserJoinGroupRepository userJoinGroupRepository;
 	private final JwtService jwtService;
 
 	@Override

--- a/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
@@ -6,7 +6,7 @@ import dnd.studyplanner.domain.user.model.UserJoinGroup;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.jwt.JwtService;
 import dnd.studyplanner.repository.StudyGroupRepository;
-import dnd.studyplanner.repository.UserJoinGroupRepository;
+// import dnd.studyplanner.repository.UserJoinGroupRepository;
 import dnd.studyplanner.repository.UserRepository;
 import dnd.studyplanner.service.IStudyGroupService;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ public class StudyGroupService implements IStudyGroupService {
 
 	private final UserRepository userRepository;
 	private final StudyGroupRepository studyGroupRepository;
-	private final UserJoinGroupRepository userJoinGroupRepository;
+	// private final UserJoinGroupRepository userJoinGroupRepository;
 	private final JwtService jwtService;
 
 	@Override

--- a/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
@@ -3,7 +3,7 @@ package dnd.studyplanner.service.Impl;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserJoinGroup;
-import dnd.studyplanner.dto.response.StudyGroupSaveResponse;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 import dnd.studyplanner.jwt.JwtService;
@@ -40,6 +40,8 @@ public class StudyGroupService implements IStudyGroupService {
 
 		StudyGroup updateStudyGroup = saveStudyGroup(studyGroupSaveDto, accessToken);
 		Long updateGroupId = updateStudyGroup.getId();
+
+		log.debug("[생성된 그룹 아이디] : {}", updateGroupId);
 
 		List<UserJoinGroup> invitedPeopleList = new ArrayList<>();
 		List<String> updateStudyGroupMemberList = new ArrayList<>();

--- a/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
@@ -3,7 +3,9 @@ package dnd.studyplanner.service.Impl;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserJoinGroup;
+import dnd.studyplanner.dto.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
+import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 import dnd.studyplanner.jwt.JwtService;
 import dnd.studyplanner.repository.StudyGroupRepository;
 import dnd.studyplanner.repository.UserJoinGroupRepository;
@@ -34,7 +36,40 @@ public class StudyGroupService implements IStudyGroupService {
 	private final JwtService jwtService;
 
 	@Override
-	public StudyGroup saveStudyGroup(StudyGroupSaveDto studyGroupSaveDto, String userAccessToken) {
+	public StudyGroupSaveResponse saveGroupAndInvite(StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto, String accessToken) {
+
+		StudyGroup updateStudyGroup = saveStudyGroup(studyGroupSaveDto, accessToken);
+		Long updateGroupId = updateStudyGroup.getId();
+
+		List<UserJoinGroup> invitedPeopleList = new ArrayList<>();
+		List<String> updateStudyGroupMemberList = new ArrayList<>();
+
+		StudyGroup joinStudyGroup = studyGroupRepository.findById(updateGroupId).get();
+
+		Long currentUserId = getCurrentUserId(accessToken);
+		User hostUser = userRepository.findById(currentUserId).get();
+		UserJoinGroup updateHostPeople = userJoinGroupSaveDto.toEntity(hostUser,joinStudyGroup);
+		invitedPeopleList.add(updateHostPeople);
+		updateStudyGroupMemberList.add(hostUser.getUserEmail());
+
+		for (String invitedPeople : studyGroupSaveDto.getInvitedUserEmailList()) {
+			User invitedUser = userRepository.findByUserEmail(invitedPeople).get();
+			UserJoinGroup updateInvitedPeople = userJoinGroupSaveDto.toEntity(invitedUser, joinStudyGroup);
+			invitedPeopleList.add(updateInvitedPeople);
+			updateStudyGroupMemberList.add(invitedPeople);
+		}
+
+		userJoinGroupRepository.saveAll(invitedPeopleList);
+
+		StudyGroupSaveResponse studyGroupSaveResponse = StudyGroupSaveResponse.builder()
+															.newStudyGroup(updateStudyGroup)
+															.studyGroupMember(updateStudyGroupMemberList)
+															.build();
+
+		return studyGroupSaveResponse;
+	}
+
+	private StudyGroup saveStudyGroup(StudyGroupSaveDto studyGroupSaveDto, String userAccessToken) {
 
 		Long currentUserId = getCurrentUserId(userAccessToken);
 		Optional<User> user = userRepository.findById(currentUserId);

--- a/src/main/java/dnd/studyplanner/service/Impl/UserRateService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/UserRateService.java
@@ -32,13 +32,12 @@ public class UserRateService implements IUserRateService {
 	private final GoalRepository goalRepository;
 
 	@Override
-	public UserGoalRate updateAfterQuestionBook(String accessToken, Long questionBookId) {
+	public UserGoalRate updateAfterQuestionBook(UserGoalRate userGoalRate) {
+		int minSolveQuestionBook = userGoalRate.getGoal().getMinSolveQuestionBook();
 
-		Optional<QuestionBook> questionBook = questionBookRepository.findById(questionBookId);
-		Goal goal = questionBook.get().getQuestionBookGoal();
-
-		UserGoalRate userGoalRate = getUserGoalRate(accessToken, goal);
-		userGoalRate.updateQuestionBookSolve(goal.getRatePerQuestionBook());
+		int ratePerQuestionBook = (50 / minSolveQuestionBook);
+		userGoalRate.updateQuestionBookSolve(ratePerQuestionBook);
+		return userGoalRate;
 	}
 
 	@Override
@@ -50,10 +49,12 @@ public class UserRateService implements IUserRateService {
 	}
 
 	@Override
-	public void updatePostQuestionBook(String accessToken, Long goalId) {
+	public UserGoalRate updatePostQuestionBook(String accessToken, Long goalId) {
 		Goal goal = goalRepository.findById(goalId).get();
 		UserGoalRate userGoalRate = getUserGoalRate(accessToken, goal);
 		userGoalRate.updatePostQuestionBook();
+
+		return userGoalRate;
 	}
 
 	private UserGoalRate getUserGoalRate(String accessToken, Goal goal) {

--- a/src/main/java/dnd/studyplanner/service/Impl/UserRateService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/UserRateService.java
@@ -1,0 +1,62 @@
+package dnd.studyplanner.service.Impl;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.domain.user.model.UserGoalRate;
+import dnd.studyplanner.jwt.JwtService;
+import dnd.studyplanner.repository.QuestionBookRepository;
+import dnd.studyplanner.repository.UserGoalRateRepository;
+import dnd.studyplanner.repository.UserRepository;
+import dnd.studyplanner.service.IUserRateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserRateService implements IUserRateService {
+
+	private final JwtService jwtService;
+
+	private final UserGoalRateRepository userGoalRateRepository;
+	private final QuestionBookRepository questionBookRepository;
+	private final UserRepository userRepository;
+
+	@Override
+	public UserGoalRate updateAfterQuestionBook(String accessToken, Long questionBookId) {
+		Long userId = jwtService.getUserId(accessToken);
+		Optional<User> user = userRepository.findById(userId);
+		Optional<QuestionBook> questionBook = questionBookRepository.findById(questionBookId);
+		Goal goal = questionBook.get().getQuestionBookGoal();
+
+		UserGoalRate userGoalRate = userGoalRateRepository.findByUser_IdAndGoal_Id(userId, goal.getId()).orElse(
+			UserGoalRate.builder()
+				.user(user.get())
+				.goal(goal)
+				.build());
+		userGoalRate.updateQuestionBookSolve(goal.getRatePerQuestionBook());
+	}
+
+	@Override
+	public UserGoalRate getUserGoalRateByQuestionBookId(String accessToken, Long questionBookId) {
+		Long userId = jwtService.getUserId(accessToken);
+
+		Optional<User> user = userRepository.findById(userId);
+		Optional<QuestionBook> questionBook = questionBookRepository.findById(questionBookId);
+		Goal goal = questionBook.get().getQuestionBookGoal();
+
+		return userGoalRateRepository.findByUser_IdAndGoal_Id(userId, goal.getId()).orElse(
+			UserGoalRate.builder()
+				.user(user.get())
+				.goal(goal)
+				.build()
+		);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     include: oauth, dev
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/dnd/studyplanner/service/QuestionBookServiceTest.java
+++ b/src/test/java/dnd/studyplanner/service/QuestionBookServiceTest.java
@@ -95,7 +95,7 @@ class QuestionBookServiceTest {
 		QuestionBookDto questionBookDto = dataUtil.getQuestionBookDto();
 
 		//when
-		questionBookService.saveQuestionBook(questionBookDto);
+		questionBookService.saveQuestionBook("accessTokne", questionBookDto);
 
 		List<Question> allQuestions = questionRepository.findAll();
 		List<Option> allOptions = optionRepository.findAll();


### PR DESCRIPTION
# Issue #35 (User로 실시간 문제집 조회)
- User ->StudyGroup -> Goal -> QuestinoBook 까지 연관관계가 깊어서 User와 QuestionBook을 매핑하는 Table을 추가하였습니다.
기존 UserSolveQuestionBook에 풀이여부 상태를 추가했어요 
UserId로 연관되는 QuestionBook을 생성 순으로 정렬하여 응답하도록 구현했습니다. 추가된 로직은 QuestionBook이 생성될 때 관계있는 사용자들을 찾아 UserSolveQuestionBook에 풀이 상태가 false로 추가됩니다!!

# 추가된 기능
- 실시간 문제집 조회 (By User)
- 문제집 완료 후 달성률 반영
-> 달성률을 매번 계산하는 것 보다, UserGoalRate라는 중간 테이블을 통해서 목표 달성률 상태로 가질 수 있도록 했습니다. (de3881e20291109475e12e8766c777f7e8906993)
추가로 문제집 출제 후에도 반영될 수 있도록 하였습니다

\+ 미경님이 PR하신거 pull해와서 통합적으로 수정했어요. 충돌 사항은 없었고요
PR에 답했던 것처럼 문제 풀이, 출제, 정답 기준 같은 조건을 세부목표(Goal)에 추가 수정만 했습니다!
좀 많긴 한데... 확인하시고 괜찮으시면 Merge도 바로 해주세욥!