### PR TITLE
Fix/post api

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/UserController.java
+++ b/src/main/java/dnd/studyplanner/controller/UserController.java
@@ -2,8 +2,10 @@ package dnd.studyplanner.controller;
 
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.dto.response.CustomResponse;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupListResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
+import dnd.studyplanner.service.IStudyGroupService;
 import dnd.studyplanner.service.IUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 
 import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -19,6 +23,7 @@ import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
 public class UserController {
 
     private final IUserService userService;
+    private final IStudyGroupService studyGroupService;
 
     @PostMapping("/info")
     public ResponseEntity<CustomResponse> addUserInfo (
@@ -45,6 +50,14 @@ public class UserController {
             return new CustomResponse<>(false, NOT_EXIST_USER).toResponseEntity();
         }
         return new CustomResponse<>(userInfoExistDto.getUserEmail(), SUCCESS).toResponseEntity();
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<CustomResponse> getStudyGroupList(
+            @RequestHeader(value = "Access-Token") String accessToken) {
+
+        List<StudyGroupListResponse> groupList = userService.getStudyGroupList(accessToken);
+        return new CustomResponse<>(groupList, GET_GROUP_SUCCESS).toResponseEntity();
     }
 
 }

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/response/StudyGroupListResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/response/StudyGroupListResponse.java
@@ -1,0 +1,44 @@
+package dnd.studyplanner.dto.studyGroup.response;
+
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupStatus;
+import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.domain.user.model.UserJoinGroup;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupListResponse {
+
+    private Long groupId;
+    private String groupName;
+    private LocalDate groupStartDate;
+    private LocalDate groupEndDate;
+    private String groupGoal;
+    private String groupImageUrl;
+    private String groupCategory;
+    private StudyGroupStatus groupStatus;
+
+//    private User groupUserList;
+
+
+    @Builder
+    public StudyGroupListResponse(Long groupId, String groupName, LocalDate groupStartDate, LocalDate groupEndDate,
+                                  String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus, UserJoinGroup userJoinGroup) {
+        this.groupId = groupId;
+        this.groupName = groupName;
+        this.groupStartDate = groupStartDate;
+        this.groupEndDate = groupEndDate;
+        this.groupGoal = groupGoal;
+        this.groupImageUrl = groupImageUrl;
+        this.groupCategory = groupCategory;
+        this.groupStatus = groupStatus;
+//        this.groupUserList = userJoinGroup.getUser();
+    }
+}

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/response/StudyGroupListResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/response/StudyGroupListResponse.java
@@ -25,12 +25,9 @@ public class StudyGroupListResponse {
     private String groupCategory;
     private StudyGroupStatus groupStatus;
 
-//    private User groupUserList;
-
-
     @Builder
     public StudyGroupListResponse(Long groupId, String groupName, LocalDate groupStartDate, LocalDate groupEndDate,
-                                  String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus, UserJoinGroup userJoinGroup) {
+                                  String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
         this.groupId = groupId;
         this.groupName = groupName;
         this.groupStartDate = groupStartDate;
@@ -39,6 +36,6 @@ public class StudyGroupListResponse {
         this.groupImageUrl = groupImageUrl;
         this.groupCategory = groupCategory;
         this.groupStatus = groupStatus;
-//        this.groupUserList = userJoinGroup.getUser();
+
     }
 }

--- a/src/main/java/dnd/studyplanner/service/IUserService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserService.java
@@ -1,9 +1,11 @@
 package dnd.studyplanner.service;
 
 import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupListResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
-import java.util.Optional;
+
+import java.util.List;
 
 public interface IUserService {
 
@@ -12,4 +14,6 @@ public interface IUserService {
     boolean checkExistUser(UserInfoExistDto userInfoExistDto);
 
     boolean isValidEmail(String userMail);
+
+    List<StudyGroupListResponse> getStudyGroupList(String accessToken);
 }

--- a/src/main/java/dnd/studyplanner/service/Impl/UserService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/UserService.java
@@ -31,8 +31,6 @@ import java.util.stream.Collectors;
 public class UserService implements IUserService {
 
     private final UserRepository userRepository;
-    private final UserJoinGroupRepository userJoinGroupRepository;
-    private final StudyGroupRepository studyGroupRepository;
     private final JwtService jwtService;
 
     public User saveUserInfo(UserInfoSaveDto userInfoSaveDto, String userAccessToken) {

--- a/src/main/java/dnd/studyplanner/service/Impl/UserService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/UserService.java
@@ -1,26 +1,38 @@
 package dnd.studyplanner.service.Impl;
 
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.user.model.User;
+import dnd.studyplanner.domain.user.model.UserJoinGroup;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupListResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
 import dnd.studyplanner.jwt.JwtService;
+import dnd.studyplanner.repository.StudyGroupRepository;
+import dnd.studyplanner.repository.UserJoinGroupRepository;
 import dnd.studyplanner.repository.UserRepository;
 import dnd.studyplanner.service.IUserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class UserService implements IUserService {
 
     private final UserRepository userRepository;
+    private final UserJoinGroupRepository userJoinGroupRepository;
+    private final StudyGroupRepository studyGroupRepository;
     private final JwtService jwtService;
 
     public User saveUserInfo(UserInfoSaveDto userInfoSaveDto, String userAccessToken) {
@@ -65,6 +77,35 @@ public class UserService implements IUserService {
             check = true;
         }
         return check;
+    }
+
+    @Override
+    public List<StudyGroupListResponse> getStudyGroupList(String accessToken) {
+        Long currentUserId = getCurrentUserId(accessToken);
+        User user = userRepository.findById(currentUserId).get();
+
+        List<UserJoinGroup> userJoinGroupList = user.getUserJoinGroups();
+        List<StudyGroup> userStudyGroupList = new ArrayList<>();
+
+        for (UserJoinGroup userJoinGroup : userJoinGroupList) {
+            userStudyGroupList.add(userJoinGroup.getStudyGroup());
+            log.debug("[GROUP NAME] : {}", userJoinGroup.getStudyGroup().getGroupName());
+        }
+
+        List<StudyGroupListResponse> userStudyGroupListResult = userStudyGroupList.stream()
+                .map(userGroup -> StudyGroupListResponse.builder()
+                    .groupId(userGroup.getId())
+                    .groupName(userGroup.getGroupName())
+                    .groupStartDate(userGroup.getGroupStartDate())
+                    .groupEndDate(userGroup.getGroupEndDate())
+                    .groupGoal(userGroup.getGroupGoal())
+                    .groupImageUrl(userGroup.getGroupImageUrl())
+                    .groupCategory(userGroup.getGroupCategory())
+                    .groupStatus(userGroup.getGroupStatus())
+                        .build())
+                .collect(Collectors.toList());
+
+        return userStudyGroupListResult;
     }
 
     private Long getCurrentUserId(String userAccessToken) {


### PR DESCRIPTION
- 사용자 (가입된) 스터디 그룹 전체 조회

- 추가적으로 조회할 때 필요한 부분 커멘트 달아주세요!!

- Default 카테고리 및 카테고리에 따른 조회 / 현재 진행중인 세부 목표..? 

- 그룹 조회시 그룹의 상태(활동전/활동중/종료)에 따른 조회 부분을 추가하나요? (그룹 활동 상태에 따른 표기를 처리해야 한다면 추가해야할 것 같습니다!)

    - 그룹 상태 관리 필요

    - 그룹별 세부목표 조회 부분도 동일하게 처리 필요한지!