### PR TITLE
Fix/question book solve

### DIFF
--- a/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestionBook.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestionBook.java
@@ -51,4 +51,10 @@ public class UserSolveQuestionBook extends BaseEntity {
 		this.isSolved = false;
 		this.isPassed = false;
 	}
+
+	public void updateAfterSolve(boolean isPassed, int answerNum) {
+		this.isSolved = true;
+		this.isPassed = isPassed;
+		this.answerNum = answerNum;
+	}
 }

--- a/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookDto.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/request/QuestionBookDto.java
@@ -19,6 +19,7 @@ public class QuestionBookDto {
 
 	private Long goalId;
 	private String questionBookName;
+	private int questionBookQuestionNum;
 
 	private List<QuestionListDto> questionDtoList = new ArrayList<>();
 
@@ -35,8 +36,8 @@ public class QuestionBookDto {
 		return QuestionBook.builder()
 			.questionBookGoal(goal)
 			.questionBookCreateUser(user)
+			.questionBookQuestionNum(this.questionBookQuestionNum)
 			.questionBookName(this.questionBookName)
 			.build();
 	}
-
 }

--- a/src/main/java/dnd/studyplanner/repository/QuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/QuestionBookRepository.java
@@ -1,8 +1,13 @@
 package dnd.studyplanner.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 
 public interface QuestionBookRepository extends JpaRepository<QuestionBook, Long> {
+
+	Optional<QuestionBook> findByQuestionBookGoal_IdOrderByCreatedDateDesc(Long goalId);
 }

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -1,6 +1,7 @@
 package dnd.studyplanner.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
 
 public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolveQuestionBook, Long> {
 	List<UserSolveQuestionBook> findAllBySolveUser_IdOrderByCreatedDateDesc(Long id);
+
+	Optional<UserSolveQuestionBook> findByUser_IdAndQuestionBook_Id(Long userId, Long questionBookId);
 }

--- a/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
@@ -13,4 +13,6 @@ public interface IQuestionBookService {
 	List<UserQuestionBookResponse> getAllUserQuestionBooks(String accessToken);
 
 	boolean isPassQuestionBook(String accessToken, SolveQuestionBookDto requestDto);
+
+	public int getRecentQuestionBookCount(Long userId, Long goalId);
 }

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -124,11 +124,16 @@ public class QuestionBookService implements IQuestionBookService {
 		// Question Book이 포함된 목표의 최소 정답률과 비교
 		Goal goal = questionBook.get().getQuestionBookGoal();
 
-		// 문제집 Pass시 기존 달성률에 문제집의 비중을 더함.
+		boolean isPass = false;
 		if (answerCount >= goal.getMinAnswerPerQuestionBook()) {
-			return true;
+			isPass = true;
 		}
-		return false;
+
+		UserSolveQuestionBook userSolveQuestionBook = userSolveQuestionBookRepository.findByUser_IdAndQuestionBook_Id(
+			userId, questionBookId).get();
+		userSolveQuestionBook.updateAfterSolve(isPass, answerCount);
+		
+		return isPass;
 	}
 
 	/**

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -136,6 +136,27 @@ public class QuestionBookService implements IQuestionBookService {
 		return isPass;
 	}
 
+
+	@Override
+	public int getRecentQuestionBookCount(Long userId, Long goalId) {
+		// 조회하는 세부목표에 가장 최근에 추가된 문제집
+		QuestionBook recentQuestionBook = questionBookRepository
+			.findByQuestionBookGoal_IdOrderByCreatedDateDesc(goalId)
+			.get();
+
+		UserSolveQuestionBook userSolveQuestionBook = userSolveQuestionBookRepository
+			.findByUser_IdAndQuestionBook_Id(userId, recentQuestionBook.getId())
+			.get();
+
+		// 가장 최근에 추가된 문제집을 풀었으면 return 0
+		if (userSolveQuestionBook.isSolved()) {
+			return 0;
+		}
+
+		// 아직 풀지 않았다면, 문제집 개수 반환
+		return recentQuestionBook.getQuestionBookQuestionNum();
+	}
+
 	/**
 	 * 풀어야할 User와 새로 생성된 QuestionBook 의 관계 저장
 	 * @param goal

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionService.java
@@ -18,7 +18,6 @@ import dnd.studyplanner.repository.QuestionRepository;
 import dnd.studyplanner.repository.UserRepository;
 import dnd.studyplanner.repository.UserSolveQuestionRepository;
 import dnd.studyplanner.service.IQuestionService;
-import dnd.studyplanner.service.IUserService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor


### PR DESCRIPTION
# 추가
스터디 그룹 조회 페이지에 세부목표별 추가된 문제 수를 반환 해야함.
이에 사용될 `getRecentQuestionBookCount` 메서드 추가

userId, goalId 로 조회할 수 있게 했습니다..! 이거 받으셔서 스터디 조회 페이지 구현하시면 될 것 같습니다!


### 수정
- [문제집 풀이 후 중간테이블에 반영](https://github.com/dnd-side-project/dnd-7th-9-backend/commit/e98f7282d1a27d72af097f8f6c87eddd261250e2)
- [문제집 저장 Dto 수정](https://github.com/dnd-side-project/dnd-7th-9-backend/commit/a9f89361fded9e58bba6a1a94f65c0d91173be00)