### PR TITLE
feat/post-api

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
+++ b/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
@@ -1,5 +1,6 @@
 package dnd.studyplanner.controller;
 
+import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
 import dnd.studyplanner.dto.response.CustomResponse;
 import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
@@ -9,7 +10,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 import static dnd.studyplanner.dto.response.CustomResponseStatus.SAVE_GROUP_SUCCESS;
+import static dnd.studyplanner.dto.response.CustomResponseStatus.SUCCESS;
 
 @RequiredArgsConstructor
 @RequestMapping("/group")
@@ -17,6 +21,17 @@ import static dnd.studyplanner.dto.response.CustomResponseStatus.SAVE_GROUP_SUCC
 public class StudyGroupController {
 
     private final IStudyGroupService studyGroupService;
+
+    // 스터디 그룹 생성 시 카테고리 리스트 조회
+    @GetMapping("/category")
+    public ResponseEntity<CustomResponse> getStudyGroupCategory(
+            @RequestHeader(value = "Access-Token") String accessToken
+    ) {
+        List<StudyGroupCategory> studyGroupCategoryList = studyGroupService.getCategoryList(accessToken);
+
+        return new CustomResponse<>(studyGroupCategoryList, SUCCESS).toResponseEntity();
+    }
+
 
     // 그룹 생성 & 사용자 초대
     @PostMapping("/info")

--- a/src/main/java/dnd/studyplanner/controller/UserController.java
+++ b/src/main/java/dnd/studyplanner/controller/UserController.java
@@ -2,7 +2,8 @@ package dnd.studyplanner.controller;
 
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.dto.response.CustomResponse;
-import dnd.studyplanner.dto.studyGroup.response.StudyGroupListResponse;
+import dnd.studyplanner.dto.user.request.UserIdDto;
+import dnd.studyplanner.dto.user.response.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
 import dnd.studyplanner.service.IStudyGroupService;
@@ -52,12 +53,12 @@ public class UserController {
         return new CustomResponse<>(userInfoExistDto.getUserEmail(), SUCCESS).toResponseEntity();
     }
 
-    @GetMapping("/list")
-    public ResponseEntity<CustomResponse> getStudyGroupList(
-            @RequestHeader(value = "Access-Token") String accessToken) {
+    @PostMapping("/list")
+    public ResponseEntity<CustomResponse> getUserStudyGroupList(
+            @RequestHeader(value = "Access-Token") String accessToken,
+            @RequestBody UserIdDto userIdDto) {
 
-        List<StudyGroupListResponse> groupList = userService.getStudyGroupList(accessToken);
-        return new CustomResponse<>(groupList, GET_GROUP_SUCCESS).toResponseEntity();
+        List<StudyGroupListGetResponse> userGroupList = userService.getUserStudyGroupList(accessToken, userIdDto.getUserId());
+        return new CustomResponse<>(userGroupList, GET_GROUP_SUCCESS).toResponseEntity();
     }
-
 }

--- a/src/main/java/dnd/studyplanner/controller/UserController.java
+++ b/src/main/java/dnd/studyplanner/controller/UserController.java
@@ -53,12 +53,11 @@ public class UserController {
         return new CustomResponse<>(userInfoExistDto.getUserEmail(), SUCCESS).toResponseEntity();
     }
 
-    @PostMapping("/list")
+    @GetMapping("/list")
     public ResponseEntity<CustomResponse> getUserStudyGroupList(
-            @RequestHeader(value = "Access-Token") String accessToken,
-            @RequestBody UserIdDto userIdDto) {
+            @RequestHeader(value = "Access-Token") String accessToken) {
 
-        List<StudyGroupListGetResponse> userGroupList = userService.getUserStudyGroupList(accessToken, userIdDto.getUserId());
+        List<StudyGroupListGetResponse> userGroupList = userService.getUserStudyGroupList(accessToken);
         return new CustomResponse<>(userGroupList, GET_GROUP_SUCCESS).toResponseEntity();
     }
 }

--- a/src/main/java/dnd/studyplanner/domain/goal/model/Goal.java
+++ b/src/main/java/dnd/studyplanner/domain/goal/model/Goal.java
@@ -5,18 +5,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
+import javax.persistence.*;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
@@ -41,10 +32,12 @@ public class Goal extends BaseEntity {
 	private StudyGroup studyGroup;
 
 	private String goalContent;
-
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	private LocalDate goalStartDate;
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	private LocalDate goalEndDate;
 
+	@Enumerated(EnumType.STRING)
 	private GoalStatus goalStatus;
 
 	private int minQuestionPerQuestionBook;   // 문제집 당 최소 문제 수

--- a/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroup.java
+++ b/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroup.java
@@ -16,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.goal.model.Goal;
 import dnd.studyplanner.domain.user.model.User;
@@ -41,11 +42,15 @@ public class StudyGroup extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User groupCreateUser;
 
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	private LocalDate groupStartDate;
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	private LocalDate groupEndDate;
 	private String groupGoal;
 	private String groupImageUrl;
-	private String groupCategory;
+
+	@Enumerated(EnumType.STRING)
+	private StudyGroupCategory groupCategory;
 
 	@Enumerated(EnumType.STRING)
 	private StudyGroupStatus groupStatus;
@@ -58,7 +63,7 @@ public class StudyGroup extends BaseEntity {
 
 	@Builder
 	public StudyGroup(String groupName, User groupCreateUser, LocalDate groupStartDate, LocalDate groupEndDate,
-		String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
+		String groupGoal, String groupImageUrl, StudyGroupCategory groupCategory, StudyGroupStatus groupStatus) {
 		this.groupName = groupName;
 		this.groupCreateUser = groupCreateUser;
 		this.groupStartDate = groupStartDate;
@@ -70,7 +75,7 @@ public class StudyGroup extends BaseEntity {
 	}
 
 	public void update(String groupName, User groupCreateUser, LocalDate groupStartDate, LocalDate groupEndDate,
-		String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
+		String groupGoal, String groupImageUrl, StudyGroupCategory groupCategory, StudyGroupStatus groupStatus) {
 
 		this.groupName = groupName;
 		this.groupCreateUser = groupCreateUser;

--- a/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroupCategory.java
+++ b/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroupCategory.java
@@ -1,0 +1,9 @@
+package dnd.studyplanner.domain.studygroup.model;
+
+public enum StudyGroupCategory {
+
+    EMPLOYMENT,
+    LANGUAGE,
+    CERTIFICATE,
+    ETC;
+}

--- a/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroupStatus.java
+++ b/src/main/java/dnd/studyplanner/domain/studygroup/model/StudyGroupStatus.java
@@ -3,5 +3,5 @@ package dnd.studyplanner.domain.studygroup.model;
 public enum StudyGroupStatus {
 	READY,
 	ACTIVE,
-	COMPLETE
+	COMPLETE;
 }

--- a/src/main/java/dnd/studyplanner/dto/goal/response/ActiveGoalResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/goal/response/ActiveGoalResponse.java
@@ -1,0 +1,46 @@
+package dnd.studyplanner.dto.goal.response;
+
+import java.time.LocalDate;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.goal.model.GoalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ActiveGoalResponse {
+
+	private String goalContent;
+
+	private LocalDate goalStartDate;
+
+	private LocalDate goalEndDate;
+
+	private GoalStatus goalStatus;
+
+	private boolean achieveGoalStatus;   // 세부 목표 달성 여부
+
+	private boolean checkSubmitQuestionBook;   // 문제 제출 여부
+
+	private boolean checkSolveQuestionBook;   // 문제 풀기 완료 여부
+
+	private int clearSolveQuestionBookNum;   // 풀기를 완료한 문제집 개수
+
+	private int toSolveQuestionBookNum;   // 풀어야 하는 문제집 개수
+
+	@Builder
+	public ActiveGoalResponse(Goal goal, boolean achieveGoalStatus, boolean checkSubmitQuestionBook, boolean checkSolveQuestionBook,
+							  int clearSolveQuestionBookNum, int toSolveQuestionBookNum) {
+
+		this.goalContent = goal.getGoalContent();
+		this.goalStartDate = goal.getGoalStartDate();
+		this.goalEndDate = goal.getGoalEndDate();
+		this.goalStatus = goal.getGoalStatus();
+		this.achieveGoalStatus = achieveGoalStatus;
+		this.checkSubmitQuestionBook = checkSubmitQuestionBook;
+		this.checkSolveQuestionBook = checkSolveQuestionBook;
+		this.clearSolveQuestionBookNum = clearSolveQuestionBookNum;
+		this.toSolveQuestionBookNum = toSolveQuestionBookNum;
+	}
+
+}

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/request/StudyGroupSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/request/StudyGroupSaveDto.java
@@ -5,9 +5,12 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
 import dnd.studyplanner.domain.studygroup.model.StudyGroupStatus;
 import dnd.studyplanner.domain.user.model.User;
 import lombok.*;
+
+import javax.persistence.Enumerated;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,7 +26,8 @@ public class StudyGroupSaveDto {
 
 	private String groupGoal;
 	private String groupImageUrl;
-	private String groupCategory;
+
+	private StudyGroupCategory groupCategory;
 
 	@Setter
 	private StudyGroupStatus groupStatus;
@@ -32,7 +36,7 @@ public class StudyGroupSaveDto {
 
 	@Builder
 	public StudyGroupSaveDto(Long createUserId, String groupName, LocalDate groupStartDate, LocalDate groupEndDate,
-							 String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
+							 String groupGoal, String groupImageUrl, StudyGroupCategory groupCategory, StudyGroupStatus groupStatus) {
 
 		this.createUserId = createUserId;
 		this.groupName = groupName;

--- a/src/main/java/dnd/studyplanner/dto/user/request/UserIdDto.java
+++ b/src/main/java/dnd/studyplanner/dto/user/request/UserIdDto.java
@@ -1,0 +1,9 @@
+package dnd.studyplanner.dto.user.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserIdDto {
+
+    private Long userId;
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/StudyGroupListGetResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/StudyGroupListGetResponse.java
@@ -1,0 +1,20 @@
+package dnd.studyplanner.dto.user.response;
+
+import dnd.studyplanner.dto.goal.response.ActiveGoalResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StudyGroupListGetResponse {
+
+	private StudyGroupListResponse studyGroupListResponse;
+
+	private ActiveGoalResponse activeGoalResponse;
+
+	@Builder
+	public StudyGroupListGetResponse(StudyGroupListResponse studyGroupListResponse, ActiveGoalResponse activeGoalResponse) {
+		this.studyGroupListResponse = studyGroupListResponse;
+		this.activeGoalResponse = activeGoalResponse;
+	}
+
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/StudyGroupListResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/StudyGroupListResponse.java
@@ -1,4 +1,4 @@
-package dnd.studyplanner.dto.studyGroup.response;
+package dnd.studyplanner.dto.user.response;
 
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.studygroup.model.StudyGroupStatus;

--- a/src/main/java/dnd/studyplanner/dto/user/response/StudyGroupListResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/StudyGroupListResponse.java
@@ -1,16 +1,14 @@
 package dnd.studyplanner.dto.user.response;
 
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
 import dnd.studyplanner.domain.studygroup.model.StudyGroupStatus;
-import dnd.studyplanner.domain.user.model.User;
-import dnd.studyplanner.domain.user.model.UserJoinGroup;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,20 +20,20 @@ public class StudyGroupListResponse {
     private LocalDate groupEndDate;
     private String groupGoal;
     private String groupImageUrl;
-    private String groupCategory;
+    private StudyGroupCategory groupCategory;
     private StudyGroupStatus groupStatus;
 
+
     @Builder
-    public StudyGroupListResponse(Long groupId, String groupName, LocalDate groupStartDate, LocalDate groupEndDate,
-                                  String groupGoal, String groupImageUrl, String groupCategory, StudyGroupStatus groupStatus) {
-        this.groupId = groupId;
-        this.groupName = groupName;
-        this.groupStartDate = groupStartDate;
-        this.groupEndDate = groupEndDate;
-        this.groupGoal = groupGoal;
-        this.groupImageUrl = groupImageUrl;
-        this.groupCategory = groupCategory;
-        this.groupStatus = groupStatus;
+    public StudyGroupListResponse(StudyGroup studyGroup) {
+        this.groupId = studyGroup.getId();
+        this.groupName = studyGroup.getGroupName();
+        this.groupStartDate = studyGroup.getGroupStartDate();
+        this.groupEndDate = studyGroup.getGroupEndDate();
+        this.groupGoal = studyGroup.getGroupGoal();
+        this.groupImageUrl = studyGroup.getGroupImageUrl();
+        this.groupCategory = studyGroup.getGroupCategory();
+        this.groupStatus = studyGroup.getGroupStatus();
 
     }
 }

--- a/src/main/java/dnd/studyplanner/repository/GoalRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/GoalRepository.java
@@ -1,8 +1,19 @@
 package dnd.studyplanner.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.goal.model.GoalStatus;
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+	Optional<Goal> findByGoalStatus(GoalStatus goalStatus);
+
+	List<Goal> findByStudyGroup(StudyGroup studyGroup);
+
+	Goal findFirstByStudyGroupOrderByGoalStartDateDesc(StudyGroup studyGroup);
 }

--- a/src/main/java/dnd/studyplanner/repository/QuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/QuestionBookRepository.java
@@ -1,6 +1,5 @@
 package dnd.studyplanner.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +9,5 @@ import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 public interface QuestionBookRepository extends JpaRepository<QuestionBook, Long> {
 
 	Optional<QuestionBook> findByQuestionBookGoal_IdOrderByCreatedDateDesc(Long goalId);
+
 }

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
 
 public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolveQuestionBook, Long> {
+
+	// 사용자가 풀어야 하는 문제집 리스트 조회 - 최근 등록일 순 ?
 	List<UserSolveQuestionBook> findAllBySolveUser_IdOrderByCreatedDateDesc(Long id);
 
-	Optional<UserSolveQuestionBook> findByUser_IdAndQuestionBook_Id(Long userId, Long questionBookId);
+	Optional<UserSolveQuestionBook> findBySolveUserIdAndSolveQuestionBookId(Long userId, Long questionBookId);
 }

--- a/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
@@ -1,11 +1,15 @@
 package dnd.studyplanner.service;
 
+import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
 import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
+
+import java.util.List;
 
 public interface IStudyGroupService {
 
 	StudyGroupSaveResponse saveGroupAndInvite(StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto, String accessToken);
 
+	List<StudyGroupCategory> getCategoryList(String accessToken);
 }

--- a/src/main/java/dnd/studyplanner/service/IUserService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserService.java
@@ -15,5 +15,5 @@ public interface IUserService {
 
     boolean isValidEmail(String userMail);
 
-    List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken, Long userId);
+    List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken);
 }

--- a/src/main/java/dnd/studyplanner/service/IUserService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserService.java
@@ -1,7 +1,7 @@
 package dnd.studyplanner.service;
 
 import dnd.studyplanner.domain.user.model.User;
-import dnd.studyplanner.dto.studyGroup.response.StudyGroupListResponse;
+import dnd.studyplanner.dto.user.response.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
 
@@ -15,5 +15,5 @@ public interface IUserService {
 
     boolean isValidEmail(String userMail);
 
-    List<StudyGroupListResponse> getStudyGroupList(String accessToken);
+    List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken, Long userId);
 }

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -129,7 +129,7 @@ public class QuestionBookService implements IQuestionBookService {
 			isPass = true;
 		}
 
-		UserSolveQuestionBook userSolveQuestionBook = userSolveQuestionBookRepository.findByUser_IdAndQuestionBook_Id(
+		UserSolveQuestionBook userSolveQuestionBook = userSolveQuestionBookRepository.findBySolveUserIdAndSolveQuestionBookId(
 			userId, questionBookId).get();
 		userSolveQuestionBook.updateAfterSolve(isPass, answerCount);
 		
@@ -145,7 +145,7 @@ public class QuestionBookService implements IQuestionBookService {
 			.get();
 
 		UserSolveQuestionBook userSolveQuestionBook = userSolveQuestionBookRepository
-			.findByUser_IdAndQuestionBook_Id(userId, recentQuestionBook.getId())
+			.findBySolveUserIdAndSolveQuestionBookId(userId, recentQuestionBook.getId())
 			.get();
 
 		// 가장 최근에 추가된 문제집을 풀었으면 return 0
@@ -153,7 +153,7 @@ public class QuestionBookService implements IQuestionBookService {
 			return 0;
 		}
 
-		// 아직 풀지 않았다면, 문제집 개수 반환
+		// 아직 풀지 않았다면, 문제집 개수 반환 -> 추가된(전체에 대한) 문제집 수
 		return recentQuestionBook.getQuestionBookQuestionNum();
 	}
 

--- a/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/StudyGroupService.java
@@ -1,6 +1,7 @@
 package dnd.studyplanner.service.Impl;
 
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserJoinGroup;
 import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -69,6 +71,14 @@ public class StudyGroupService implements IStudyGroupService {
 															.build();
 
 		return studyGroupSaveResponse;
+	}
+
+	@Override
+	public List<StudyGroupCategory> getCategoryList(String accessToken) {
+
+		List<StudyGroupCategory> categoryList = new ArrayList<>();
+		categoryList.addAll(Arrays.asList(StudyGroupCategory.values()));
+		return categoryList;
 	}
 
 	private StudyGroup saveStudyGroup(StudyGroupSaveDto studyGroupSaveDto, String userAccessToken) {

--- a/src/main/java/dnd/studyplanner/service/Impl/UserService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/UserService.java
@@ -10,6 +10,7 @@ import dnd.studyplanner.dto.goal.response.ActiveGoalResponse;
 import dnd.studyplanner.dto.user.response.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
+import dnd.studyplanner.dto.user.response.StudyGroupListResponse;
 import dnd.studyplanner.jwt.JwtService;
 import dnd.studyplanner.repository.*;
 import dnd.studyplanner.service.IQuestionBookService;
@@ -98,12 +99,10 @@ public class UserService implements IUserService {
      *    - 문제 풀기 완료는, 전체 문제집을 푼 경우의 상태
      */
     @Override
-    public List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken, Long userId) {
+    public List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken) {
 
-//        Long currentUserId = getCurrentUserId(accessToken);
-//        User user = userRepository.findById(currentUserId).get();
-
-        User user = userRepository.findById(userId).get();
+        Long currentUserId = getCurrentUserId(accessToken);
+        User user = userRepository.findById(currentUserId).get();
 
         // 사용자가 속한 그룹에서, 각 그룹별 진행중인 세부 목표 리스트
         List<Goal> myLatestGoalListPerStudyGroup = getLatestGoalListPerGroup(user);

--- a/src/main/java/dnd/studyplanner/service/Impl/UserService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/UserService.java
@@ -1,18 +1,23 @@
 package dnd.studyplanner.service.Impl;
 
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.goal.model.GoalStatus;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
-import dnd.studyplanner.domain.user.model.User;
-import dnd.studyplanner.domain.user.model.UserJoinGroup;
-import dnd.studyplanner.dto.studyGroup.response.StudyGroupListResponse;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupStatus;
+import dnd.studyplanner.domain.user.model.*;
+import dnd.studyplanner.dto.goal.response.ActiveGoalResponse;
+import dnd.studyplanner.dto.user.response.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
 import dnd.studyplanner.jwt.JwtService;
-import dnd.studyplanner.repository.StudyGroupRepository;
-import dnd.studyplanner.repository.UserJoinGroupRepository;
-import dnd.studyplanner.repository.UserRepository;
+import dnd.studyplanner.repository.*;
+import dnd.studyplanner.service.IQuestionBookService;
+import dnd.studyplanner.service.IUserRateService;
 import dnd.studyplanner.service.IUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +27,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,7 +35,13 @@ import java.util.stream.Collectors;
 public class UserService implements IUserService {
 
     private final UserRepository userRepository;
+    private final GoalRepository goalRepository;
+    private final UserSolveQuestionBookRepository userSolveQuestionBookRepository;
+    private final UserGoalRateRepository userGoalRateRepository;
+
+    private final IUserRateService userRateService;
     private final JwtService jwtService;
+    private final IQuestionBookService questionBookService;
 
     public User saveUserInfo(UserInfoSaveDto userInfoSaveDto, String userAccessToken) {
 
@@ -77,37 +87,169 @@ public class UserService implements IUserService {
         return check;
     }
 
+    /**
+     * <Response>
+     *   1. checkSubmitQuestionBook : 사용자의 해당 세부 목표 내 문제집 출제 여부
+     *   2. checkSolveQuestionBook : 사용자의 해당 세부 목표 내 문제집 전체 풀이 여부 (푼 개수 == 풀어야 하는 개수)
+     *   3. toSolveQuestionBookNum : 사용자의 해당 세부 목표 내 풀어야 할 문제집 개수
+     *   4. clearSolveQuestionBookNum : 사용자의 해당 세부 목표 내 문제집 풀이 완료 개수 - 이때, 각 문제집을 풀 때 최소 정답 개수를 충족한 경우
+     *   5. achieveGoalStatus : 사용자의 세부 목표 달성 완료 여부
+     *    - 세부(이번) 목표 달성 완료 여부는, 출제 + 풀이 활동으로 => 100% 를 채우는 경우
+     *    - 문제 풀기 완료는, 전체 문제집을 푼 경우의 상태
+     */
     @Override
-    public List<StudyGroupListResponse> getStudyGroupList(String accessToken) {
-        Long currentUserId = getCurrentUserId(accessToken);
-        User user = userRepository.findById(currentUserId).get();
+    public List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken, Long userId) {
 
-        List<UserJoinGroup> userJoinGroupList = user.getUserJoinGroups();
-        List<StudyGroup> userStudyGroupList = new ArrayList<>();
+//        Long currentUserId = getCurrentUserId(accessToken);
+//        User user = userRepository.findById(currentUserId).get();
 
-        for (UserJoinGroup userJoinGroup : userJoinGroupList) {
-            userStudyGroupList.add(userJoinGroup.getStudyGroup());
-            log.debug("[GROUP NAME] : {}", userJoinGroup.getStudyGroup().getGroupName());
+        User user = userRepository.findById(userId).get();
+
+        // 사용자가 속한 그룹에서, 각 그룹별 진행중인 세부 목표 리스트
+        List<Goal> myLatestGoalListPerStudyGroup = getLatestGoalListPerGroup(user);
+        List<StudyGroupListGetResponse> studyGroupListGetResponseList = new ArrayList<>();
+
+        for (Goal myGoal : myLatestGoalListPerStudyGroup) {
+
+            StudyGroup myGoalInStudyGroup = myGoal.getStudyGroup();
+            studyGroupListGetResponseList.add(
+                    // 그룹 정보
+                    StudyGroupListGetResponse.builder()
+                            .studyGroupListResponse(
+                                    StudyGroupListResponse.builder()
+                                            .studyGroup(myGoalInStudyGroup)
+                                            .build()
+                            )
+                            // 세부 목표 정보
+                            .activeGoalResponse(
+                                    ActiveGoalResponse.builder()
+                                            .goal(myGoal)
+                                            .achieveGoalStatus(getAchieveGoalStatus(user, myGoal))   // 사용자의 해당 세부 목표 달성 여부
+                                            .checkSubmitQuestionBook(getCheckSubmitQuestionBook(user, myGoal))   // 사용자의 해당 세부 목표에 문제집 제출 여부
+                                            .checkSolveQuestionBook(getCheckCompleteSolveQuestionBook(user, myGoal))   // 사용자의 해당 세부 목표에서 문제 풀기 (전체?) 완료 여부
+                                            .clearSolveQuestionBookNum(getClearSolveQuestionBookNum(user, myGoal))   // 풀기를 완료한 문제집 개수
+                                            .toSolveQuestionBookNum(getToSolveQuestionBookNum(user, myGoal))   // 사용자가 해당 세부 목표에서 풀어야 하는 문제집 개수
+                                            .build()
+                            ).build()
+            );
+
         }
 
-        List<StudyGroupListResponse> userStudyGroupListResult = userStudyGroupList.stream()
-                .map(userGroup -> StudyGroupListResponse.builder()
-                    .groupId(userGroup.getId())
-                    .groupName(userGroup.getGroupName())
-                    .groupStartDate(userGroup.getGroupStartDate())
-                    .groupEndDate(userGroup.getGroupEndDate())
-                    .groupGoal(userGroup.getGroupGoal())
-                    .groupImageUrl(userGroup.getGroupImageUrl())
-                    .groupCategory(userGroup.getGroupCategory())
-                    .groupStatus(userGroup.getGroupStatus())
-                        .build())
-                .collect(Collectors.toList());
+        return studyGroupListGetResponseList;
+    }
 
-        return userStudyGroupListResult;
+    // 사용자 가입 스터디 그룹의 최근 목표 리스트 조회
+    private List<Goal> getLatestGoalListPerGroup(User user) {
+
+        List<UserJoinGroup> userJoinGroupList = user.getUserJoinGroups();
+
+        List<Goal> userLatestGoalListPerStudyGroup = new ArrayList<>();
+
+        for (UserJoinGroup userJoinGroup : userJoinGroupList) {
+            StudyGroup myStudyGroup = userJoinGroup.getStudyGroup();
+            // 스터디 그룹의 현재 상태가 ACTIVE 이며,
+            if (myStudyGroup.getGroupStatus() == StudyGroupStatus.ACTIVE) {
+                Goal latestDetailGoal = goalRepository.findFirstByStudyGroupOrderByGoalStartDateDesc(myStudyGroup);
+                // 현재 날짜 기준 세부 목표가 진행중인 경우만 추가
+                if (latestDetailGoal.getGoalStatus() == GoalStatus.ACTIVE) {
+                    userLatestGoalListPerStudyGroup.add(latestDetailGoal);
+                }
+            }
+        }
+
+        return userLatestGoalListPerStudyGroup;
+    }
+
+
+    //TODO 사용자가 해당 세부 목표를 달성하였는지 (100%) 여부
+    private boolean getAchieveGoalStatus(User user, Goal goal) {
+
+        boolean checkAchieveGoalStatus = false;
+//        UserGoalRate userLatestGoalRate = userGoalRateRepository.findByUser_IdAndGoal_Id(user.getId(), goal.getId()).get();
+        Optional<UserGoalRate> userGoalRateOptional = userGoalRateRepository.findByUser_IdAndGoal_Id(user.getId(), goal.getId());
+        if (userGoalRateOptional.isPresent()) {
+            if (userGoalRateOptional.get().isFinishGoal()) {
+                checkAchieveGoalStatus = true;
+            }
+        }
+
+        return checkAchieveGoalStatus;
+    }
+
+    //TODO 사용자가 해당 세부 목표에 문제집을 출제하였는지 여부
+    private boolean getCheckSubmitQuestionBook(User user, Goal goal) {
+
+        // 해당 그룹의 세부 목표 중 -> 출제된 문제집에서 -> 출제자 자신의 아이디 존재 ?
+        boolean isSubmitCheck = false;
+        // 해당 그룹의 세부 목표 중 -> 출제된 문제집 리스트
+        List<QuestionBook> questionBookListPerGoal = goal.getQuestionBooks();
+        for (QuestionBook questionBook : questionBookListPerGoal) {
+            if (user == questionBook.getQuestionBookCreateUser()) {
+                isSubmitCheck = true;
+            }
+        }
+        return isSubmitCheck;
+    }
+
+    //TODO 사용자의 해당 세부 목표 내 문제 풀이 완료 여부 : 풀어야할 문제집 개수 == 자신이 푼 문제집 개수 ?
+    private boolean getCheckCompleteSolveQuestionBook(User user, Goal goal) {
+
+        boolean checkCompleteSolveQuestionBook = false;
+
+        int toSolveQuestionBookNum = getToSolveQuestionBookNum(user, goal);
+        int clearSolveQuestionBookNum = getClearSolveQuestionBookNum(user, goal);
+
+        if (toSolveQuestionBookNum == clearSolveQuestionBookNum) {
+            checkCompleteSolveQuestionBook = true;
+        }
+        return checkCompleteSolveQuestionBook;
+    }
+
+    //TODO 사용자가 해당 세부 목표 내에서 풀어야 하는 문제집 리스트
+    private List<UserSolveQuestionBook> getToSolveQuestionBookList(User user, Goal goal) {
+
+        List<UserSolveQuestionBook> toSolveQuestionBookList = new ArrayList<>();
+        List<UserSolveQuestionBook> userSolveQuestionBookList = userSolveQuestionBookRepository.findAllBySolveUser_IdOrderByCreatedDateDesc(user.getId());
+
+        for (UserSolveQuestionBook userSolveQuestionBook : userSolveQuestionBookList) {
+            if (userSolveQuestionBook.getSolveQuestionBook().getQuestionBookGoal() == goal) {
+                toSolveQuestionBookList.add(userSolveQuestionBook);
+            }
+        }
+        return toSolveQuestionBookList;
+    }
+
+    //TODO 사용자가 해당 세부 목표 내에서, 풀어야 하는 문제집 개수
+    // 풀어야 하는 문제집 개수 = 해당 세부 목표 내에서 출제된 문제집 수 - 본인이 출제한 문제집 수(1)
+    private int getToSolveQuestionBookNum(User user, Goal goal) {
+
+        List<UserSolveQuestionBook> userSolveQuestionBookList = getToSolveQuestionBookList(user, goal);
+        int toSolveQuestionBookNum = userSolveQuestionBookList.size();
+
+        for (UserSolveQuestionBook userSolveQuestionBook : userSolveQuestionBookList) {
+            // 풀어야 할 문제집 개수 중에서, 본인이 출제한 문제집의 수는 제외하기
+            if (userSolveQuestionBook.getSolveQuestionBook().getQuestionBookCreateUser() == user) {
+                toSolveQuestionBookNum -= 1;
+            }
+        }
+        return toSolveQuestionBookNum;
+    }
+
+    //TODO 해당 세부 목표 내에서 사용자가 풀기를 완료한(각 문제집 당 최소 정답 개수 조건을 충족한) 문제집 개수
+    private int getClearSolveQuestionBookNum(User user, Goal goal) {
+
+        int clearQuestionBookNum = 0;
+        // 해당 세부 목표(가장 최근 세부 목표) 에 출제된 문제집 개수 중에서, 사용자 본인이 (최소 정답 개수 조건을) 통과한 문제집 개수
+        List<UserSolveQuestionBook> userSolveQuestionBookList = getToSolveQuestionBookList(user, goal);
+        for (UserSolveQuestionBook userSolveQuestionBook : userSolveQuestionBookList) {
+            if (userSolveQuestionBook.isPassed()) {
+                clearQuestionBookNum += 1;
+            }
+        }
+        return clearQuestionBookNum;
     }
 
     private Long getCurrentUserId(String userAccessToken) {
-
         Long currentUserId = jwtService.getUserId(userAccessToken);
         return currentUserId;
     }


### PR DESCRIPTION
## HOME 페이지 스터디 그룹/세부 목표 현황 조회 API

- RESPONSE 에 대한 필드값 설명은 노션 API 명세서에 추가하겠습니닷! 

- 스터디그룹/세부 목표 현황 조회 시 필요한 정보 조회를 위해 UserGoalRateService 클래스 내 함수 일부 사용하여 구현하였습니다.

- 다만, response 응답 샘플 확인 및 api 테스트를 위해 user_goal_rate 테이블에 row 한 개에 해당하는 데이터를 넣었다가 삭제하였는데, Home 페이지 및 스터디그룹 상세 조회 페이지에서 조회될 내용을 위해 문제 풀기와 관련된 데이터를 추가하는게 좋을 것 같아요!

- StudyGroup 과 Goal 테이블에도 데이터를 추가하도록 api 테스트를 여러 번 하면 좋을 것 같습니다!