### PR TITLE
fix : 인터셉터 적용 시 prefilght CORS 문제 해결

### DIFF
--- a/src/main/java/dnd/studyplanner/jwt/JwtTokenInterceptor.java
+++ b/src/main/java/dnd/studyplanner/jwt/JwtTokenInterceptor.java
@@ -8,6 +8,7 @@ import java.io.PrintWriter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -34,6 +35,10 @@ public class JwtTokenInterceptor implements HandlerInterceptor {
 	@Override
 	public boolean preHandle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler) throws
 		IOException {
+
+		if (HttpMethod.OPTIONS.matches(httpServletRequest.getMethod())) {
+			return true;
+		}
 
 		log.debug("[JWT Token Interceptor]");
 		String accessToken = jwtService.getJwt(); // Header 에 있는 Token 추출


### PR DESCRIPTION
Intecetpor 적용 시, 토큰 없이 브라우저에서 오는 prefilght에 대해 항상 예외를 반환 -> CORS로 예외 발생시킴
```java
if (HttpMethod.OPTIONS.matches(httpServletRequest.getMethod())) {
    return true;
}
```
prefilght에 대해 발생하는 검증은 예외 처리