### PR TITLE
feat/get-api

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
+++ b/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
@@ -19,6 +19,7 @@ import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.studyGroup.response.MyStudyGroupPageResponse;
 import dnd.studyplanner.dto.studyGroup.response.MyStudyGroupResponse;
 import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
+import dnd.studyplanner.dto.user.response.groupList.StudyGroupListResponse;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
 import dnd.studyplanner.service.IStudyGroupService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/dnd/studyplanner/controller/UserController.java
+++ b/src/main/java/dnd/studyplanner/controller/UserController.java
@@ -3,9 +3,11 @@ package dnd.studyplanner.controller;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.dto.response.CustomResponse;
 import dnd.studyplanner.dto.user.request.UserIdDto;
-import dnd.studyplanner.dto.user.response.StudyGroupListGetResponse;
+import dnd.studyplanner.dto.user.response.UserStudyGroupListDetailResponse;
+import dnd.studyplanner.dto.user.response.groupList.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
+import dnd.studyplanner.exception.BaseException;
 import dnd.studyplanner.service.IStudyGroupService;
 import dnd.studyplanner.service.IUserService;
 import lombok.RequiredArgsConstructor;
@@ -62,6 +64,21 @@ public class UserController {
             return new CustomResponse<>(userGroupList, GET_GROUP_SUCCESS).toResponseEntity();
         } catch (Exception e) {
             return new CustomResponse<>(NOT_EXIST_DATA).toResponseEntity();
+        }
+    }
+
+    @GetMapping("/list/detail")
+    public ResponseEntity<CustomResponse> getUserStudyGroupListDetail(
+        @RequestHeader(value = "Access-Token") String accessToken,
+        @RequestParam Long groupId,
+        @RequestParam(required = false) Long goalId,
+        @RequestParam(required = false) String version) {
+
+        try {
+            UserStudyGroupListDetailResponse userStudyGroupListDetailResponse = userService.getUserStudyGroupListDetail(accessToken, groupId, goalId, version);
+            return new CustomResponse<>(userStudyGroupListDetailResponse, GET_GROUP_DETAIL_SUCCESS).toResponseEntity();
+        } catch (BaseException e) {
+            return new CustomResponse<>(USER_NOT_IN_GROUP).toResponseEntity();
         }
     }
 }

--- a/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
+++ b/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
@@ -15,6 +15,7 @@ public enum CustomResponseStatus {
 	SAVE_GROUP_SUCCESS(true, 1300, "그룹 정보 저장 성공", HttpStatus.OK),
 	GET_GROUP_SUCCESS(true, 1301, "사용자 가입 그룹 조회 성공", HttpStatus.OK),
 	GET_MY_GROUP_SUCCESS(true, 1302, "프로필 스터디 그룹 조회 성공", HttpStatus.OK),
+	GET_GROUP_DETAIL_SUCCESS(true, 1303, "스터디 그룹 상세 정보 조회 성공", HttpStatus.OK),
 	SAVE_GOAL_SUCCESS(true, 1400, "목표 저장 성공", HttpStatus.OK),
 
 	//4000번 오류 응답코드
@@ -24,8 +25,8 @@ public enum CustomResponseStatus {
 	NOT_VALID_USER(false, 4003, "유효하지 않는 이메일 형식입니다", HttpStatus.BAD_REQUEST),
 	NOT_EXIST_USER(false, 4004, "존재하지 않는 사용자입니다", HttpStatus.NOT_FOUND),
 	NOT_VALID_STATUS(false, 4005, "옳바르지 않는 스터디 그룹 상태 입니다", HttpStatus.BAD_REQUEST),
-
 	TOKEN_NULL(false, 4006, "토큰이 존재하지 않습니다", HttpStatus.UNAUTHORIZED),
+	USER_NOT_IN_GROUP(false, 4007, "사용자가 가입한 그룹이 아닙니다", HttpStatus.BAD_REQUEST),
 	NOT_EXIST_DATA(false, 4100, "존재하지 않는 데이터입니다.", HttpStatus.BAD_REQUEST),
 
 	ALREADY_SOLVED_QUESTION_BOOK(false, 4200, "이미 풀이 완료한 문제집 입니다", HttpStatus.BAD_REQUEST),

--- a/src/main/java/dnd/studyplanner/dto/user/request/StudyGroupDetailVersion.java
+++ b/src/main/java/dnd/studyplanner/dto/user/request/StudyGroupDetailVersion.java
@@ -1,0 +1,7 @@
+package dnd.studyplanner.dto.user.request;
+
+public enum StudyGroupDetailVersion {
+
+    TEAM,
+    PERSONAL;
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/UserStudyGroupListDetailResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/UserStudyGroupListDetailResponse.java
@@ -1,0 +1,37 @@
+package dnd.studyplanner.dto.user.response;
+
+import java.util.List;
+
+import dnd.studyplanner.dto.user.response.groupAndGoalDetail.StudyGroupDetailResponse;
+import dnd.studyplanner.dto.user.response.versionDetail.StudyGroupAndGoalDetailPersonalVerResponse;
+import dnd.studyplanner.dto.user.response.versionDetail.StudyGroupAndGoalDetailTeamVerResponse;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserStudyGroupListDetailResponse {
+
+	private StudyGroupDetailResponse studyGroupDetailResponse;
+
+	/**
+	 * 개인 Ver 문제집 목록
+	 */
+	private List<StudyGroupAndGoalDetailPersonalVerResponse> studyGroupAndGoalDetailPersonalVerResponseList;
+
+	/**
+	 * 팀 Ver 문제집 목록
+	 */
+	private List<StudyGroupAndGoalDetailTeamVerResponse> studyGroupAndGoalDetailTeamVerResponseList;
+
+	@Builder
+	public UserStudyGroupListDetailResponse(StudyGroupDetailResponse studyGroupDetailResponse,
+		List<StudyGroupAndGoalDetailPersonalVerResponse> studyGroupAndGoalDetailPersonalVerResponseList,
+		List<StudyGroupAndGoalDetailTeamVerResponse> studyGroupAndGoalDetailTeamVerResponseList) {
+		this.studyGroupDetailResponse = studyGroupDetailResponse;
+		this.studyGroupAndGoalDetailPersonalVerResponseList = studyGroupAndGoalDetailPersonalVerResponseList;
+		this.studyGroupAndGoalDetailTeamVerResponseList = studyGroupAndGoalDetailTeamVerResponseList;
+	}
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/groupAndGoalDetail/StudyGroupDetailResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/groupAndGoalDetail/StudyGroupDetailResponse.java
@@ -1,0 +1,52 @@
+package dnd.studyplanner.dto.user.response.groupAndGoalDetail;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
+import dnd.studyplanner.domain.studygroup.model.StudyGroupStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class StudyGroupDetailResponse {
+
+	/**
+	 * 스터디 그룹 정보
+	 */
+	private Long groupId;
+	private String groupName;
+	private String createUserName;   // 팀장
+//	@Setter
+	private List<String> invitedUserNameList;
+	private LocalDate groupStartDate;
+	private LocalDate groupEndDate;
+	private String groupGoal;
+	private String groupImageUrl;
+	private StudyGroupCategory groupCategory;
+	private StudyGroupStatus groupStatus;
+
+	/**
+	 * 세부 목표 정보
+	 */
+	List<StudyGroupGoalResponse> studyGroupGoalResponseList;
+
+	@Builder
+	public StudyGroupDetailResponse(StudyGroup studyGroup, List<String> invitedUserNameList, List<StudyGroupGoalResponse> studyGroupGoalResponseList) {
+		this.groupId = studyGroup.getId();
+		this.groupName = studyGroup.getGroupName();
+		this.createUserName = studyGroup.getGroupCreateUser().getUserNickName();
+		this.invitedUserNameList = invitedUserNameList;   // 추가
+		this.groupStartDate = studyGroup.getGroupStartDate();
+		this.groupEndDate = studyGroup.getGroupEndDate();
+		this.groupGoal = studyGroup.getGroupGoal();
+		this.groupImageUrl = studyGroup.getGroupImageUrl();
+		this.groupCategory = studyGroup.getGroupCategory();
+		this.groupStatus = studyGroup.getGroupStatus();
+		this.studyGroupGoalResponseList = studyGroupGoalResponseList;
+
+	}
+
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/groupAndGoalDetail/StudyGroupGoalResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/groupAndGoalDetail/StudyGroupGoalResponse.java
@@ -1,0 +1,27 @@
+package dnd.studyplanner.dto.user.response.groupAndGoalDetail;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.user.model.UserGoalRate;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class StudyGroupGoalResponse {
+
+    private Long goalId;
+    private String goalContent;
+    private LocalDate goalStartDate;
+    private LocalDate goalEndDate;
+    private int achieveRate;
+
+    @Builder
+    public StudyGroupGoalResponse(Goal goal, int achieveRate) {
+        this.goalId = goal.getId();
+        this.goalContent = goal.getGoalContent();
+        this.goalStartDate = goal.getGoalStartDate();
+        this.goalEndDate = goal.getGoalEndDate();
+        this.achieveRate = achieveRate;
+    }
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/groupList/StudyGroupListGetResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/groupList/StudyGroupListGetResponse.java
@@ -1,10 +1,13 @@
-package dnd.studyplanner.dto.user.response;
+package dnd.studyplanner.dto.user.response.groupList;
 
 import dnd.studyplanner.dto.goal.response.ActiveGoalResponse;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudyGroupListGetResponse {
 
 	private StudyGroupListResponse studyGroupListResponse;

--- a/src/main/java/dnd/studyplanner/dto/user/response/groupList/StudyGroupListResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/groupList/StudyGroupListResponse.java
@@ -1,4 +1,4 @@
-package dnd.studyplanner.dto.user.response;
+package dnd.studyplanner.dto.user.response.groupList;
 
 import dnd.studyplanner.domain.studygroup.model.StudyGroup;
 import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;

--- a/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailPersonalVerResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailPersonalVerResponse.java
@@ -15,7 +15,8 @@ import lombok.NoArgsConstructor;
 public class StudyGroupAndGoalDetailPersonalVerResponse {
 
     private Long goalId;
-    private boolean checkEditEnabled;   // 내가 출제한 문제집 수정 가능 여부 - 해당 문제집을 푼 사람이 아무도 없는 경우 수정 가능
+    private boolean myQuestionBook;   // 내가 출제한 문제집인지 여부
+    private boolean checkEditEnabled;   // 내가 출제한 문제집 수정 가능 여부 - 출제자가 나인 경우 + 해당 문제집을 푼 사람이 아무도 없는 경우 수정 가능
     private String questionBookName;   // 해당 세부 목표의 문제집 리스트 ( 본인이 출제한 문제집 제외 ) INDEX -> 문제집 + INDEX
     private String questionBookCreateUserName;   // 각 문제집을 출제한 사람 이름
     private int questionNumPerQuestionBook;   // 문제집 내의 문제 수
@@ -24,11 +25,12 @@ public class StudyGroupAndGoalDetailPersonalVerResponse {
 
 
     @Builder
-    public StudyGroupAndGoalDetailPersonalVerResponse(Goal goal, QuestionBook questionBook, boolean checkEditEnabled,
+    public StudyGroupAndGoalDetailPersonalVerResponse(Goal goal, QuestionBook questionBook, boolean myQuestionBook, boolean checkEditEnabled,
                                         int questionNumPerQuestionBook, int answerNumPerQuestionBook, boolean checkCompleteToSolve) {
         this.goalId = goal.getId();
         this.questionBookName = questionBook.getQuestionBookName();
         this.questionBookCreateUserName = questionBook.getQuestionBookCreateUser().getUserNickName();
+        this.myQuestionBook = myQuestionBook;
         this.checkEditEnabled = checkEditEnabled;   // userSolveQuestionBook.isSolved() >= 1 인 경우 false
         this.questionNumPerQuestionBook = questionNumPerQuestionBook;   // 세부 목표 ID 가 id 인 QuestionBook 의 개수
         this.answerNumPerQuestionBook = answerNumPerQuestionBook;

--- a/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailPersonalVerResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailPersonalVerResponse.java
@@ -1,0 +1,39 @@
+package dnd.studyplanner.dto.user.response.versionDetail;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 개인 Ver 문제집 목록
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupAndGoalDetailPersonalVerResponse {
+
+    private Long goalId;
+    private boolean checkEditEnabled;   // 내가 출제한 문제집 수정 가능 여부 - 해당 문제집을 푼 사람이 아무도 없는 경우 수정 가능
+    private String questionBookName;   // 해당 세부 목표의 문제집 리스트 ( 본인이 출제한 문제집 제외 ) INDEX -> 문제집 + INDEX
+    private String questionBookCreateUserName;   // 각 문제집을 출제한 사람 이름
+    private int questionNumPerQuestionBook;   // 문제집 내의 문제 수
+    private int answerNumPerQuestionBook;   // 문제집 내의 사용자가 맞춘 정답 수
+    private boolean checkCompleteToSolve;   // 각 문제집 마다 (현재 사용자 기준) 풀이 완료 여부 - 이때 풀이는, 단순히 해당 문제집을 풀었냐/안 풀었냐에 대한 응시 여부
+
+
+    @Builder
+    public StudyGroupAndGoalDetailPersonalVerResponse(Goal goal, QuestionBook questionBook, boolean checkEditEnabled,
+                                        int questionNumPerQuestionBook, int answerNumPerQuestionBook, boolean checkCompleteToSolve) {
+        this.goalId = goal.getId();
+        this.questionBookName = questionBook.getQuestionBookName();
+        this.questionBookCreateUserName = questionBook.getQuestionBookCreateUser().getUserNickName();
+        this.checkEditEnabled = checkEditEnabled;   // userSolveQuestionBook.isSolved() >= 1 인 경우 false
+        this.questionNumPerQuestionBook = questionNumPerQuestionBook;   // 세부 목표 ID 가 id 인 QuestionBook 의 개수
+        this.answerNumPerQuestionBook = answerNumPerQuestionBook;
+        this.checkCompleteToSolve = checkCompleteToSolve;
+
+    }
+
+}

--- a/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailTeamVerResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailTeamVerResponse.java
@@ -31,7 +31,7 @@ public class StudyGroupAndGoalDetailTeamVerResponse {
 
         this.goalId = goal.getId();
         this.questionBookName = questionBook.getQuestionBookName();
-        this.questionBookCreateUserName = questionBook.getQuestionBookCreateUser().getUserName();
+        this.questionBookCreateUserName = questionBook.getQuestionBookCreateUser().getUserNickName();
         this.personNumOfCompleteToSolvePerQuestionBook = personNumOfCompleteToSolvePerQuestionBook;   // userSolveQuestionBook.isSolved() 개수
         this.personListOfCompleteToSolvePerQuestionBook = personListOfCompleteToSolvePerQuestionBook;   // userSolveQuestionBook.isSolved() 인 사람의 이름 목록
     }

--- a/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailTeamVerResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/user/response/versionDetail/StudyGroupAndGoalDetailTeamVerResponse.java
@@ -1,0 +1,38 @@
+package dnd.studyplanner.dto.user.response.versionDetail;
+
+import dnd.studyplanner.domain.goal.model.Goal;
+import dnd.studyplanner.domain.questionbook.model.QuestionBook;
+import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 팀 Ver 문제집 목록
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupAndGoalDetailTeamVerResponse {
+
+    private Long goalId;
+    private String questionBookName;   // 해당 세부 목표의 문제집 리스트 ( 본인이 출제한 문제집 제외 ) INDEX -> 문제집 + INDEX
+    private String questionBookCreateUserName;   // 각 문제집을 출제한 사람 이름
+    private int personNumOfCompleteToSolvePerQuestionBook;   // 각 문제집당 푼(응시를 한) 인원
+    private List<String> personListOfCompleteToSolvePerQuestionBook;   // 각 문제집당 푼(응시를 한) 사람의 이름 목록
+
+
+    @Builder
+    public StudyGroupAndGoalDetailTeamVerResponse(Goal goal, QuestionBook questionBook,
+        int personNumOfCompleteToSolvePerQuestionBook,
+        List<String> personListOfCompleteToSolvePerQuestionBook) {
+
+        this.goalId = goal.getId();
+        this.questionBookName = questionBook.getQuestionBookName();
+        this.questionBookCreateUserName = questionBook.getQuestionBookCreateUser().getUserName();
+        this.personNumOfCompleteToSolvePerQuestionBook = personNumOfCompleteToSolvePerQuestionBook;   // userSolveQuestionBook.isSolved() 개수
+        this.personListOfCompleteToSolvePerQuestionBook = personListOfCompleteToSolvePerQuestionBook;   // userSolveQuestionBook.isSolved() 인 사람의 이름 목록
+    }
+}

--- a/src/main/java/dnd/studyplanner/repository/GoalRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/GoalRepository.java
@@ -16,4 +16,6 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
 	List<Goal> findByStudyGroup(StudyGroup studyGroup);
 
 	Goal findFirstByStudyGroupOrderByGoalStartDateDesc(StudyGroup studyGroup);
+
+	List<Goal> findAllByStudyGroupOrderByCreatedDateDesc(StudyGroup studyGroup);
 }

--- a/src/main/java/dnd/studyplanner/repository/UserJoinGroupRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserJoinGroupRepository.java
@@ -2,6 +2,8 @@ package dnd.studyplanner.repository;
 
 import java.util.List;
 
+import dnd.studyplanner.domain.studygroup.model.StudyGroup;
+import dnd.studyplanner.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.studyplanner.domain.user.model.UserJoinGroup;
@@ -9,4 +11,6 @@ import dnd.studyplanner.domain.user.model.UserJoinGroup;
 public interface UserJoinGroupRepository extends JpaRepository<UserJoinGroup, Long> {
 
 	List<UserJoinGroup> findByUserId(Long userId);
+
+	boolean existsByUserAndStudyGroup(User user, StudyGroup studyGroup);
 }

--- a/src/main/java/dnd/studyplanner/service/IUserService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserService.java
@@ -1,9 +1,12 @@
 package dnd.studyplanner.service;
 
 import dnd.studyplanner.domain.user.model.User;
-import dnd.studyplanner.dto.user.response.StudyGroupListGetResponse;
+import dnd.studyplanner.dto.user.request.UserStudyGroupListDetailDto;
+import dnd.studyplanner.dto.user.response.UserStudyGroupListDetailResponse;
+import dnd.studyplanner.dto.user.response.groupList.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;
 import dnd.studyplanner.dto.user.request.UserInfoSaveDto;
+import dnd.studyplanner.exception.BaseException;
 
 import java.util.List;
 
@@ -16,4 +19,6 @@ public interface IUserService {
     boolean isValidEmail(String userMail);
 
     List<StudyGroupListGetResponse> getUserStudyGroupList(String accessToken);
+
+    UserStudyGroupListDetailResponse getUserStudyGroupListDetail(String accessToken, Long groupId, Long goalId, String version) throws BaseException;
 }

--- a/src/main/java/dnd/studyplanner/service/IUserService.java
+++ b/src/main/java/dnd/studyplanner/service/IUserService.java
@@ -1,7 +1,6 @@
 package dnd.studyplanner.service;
 
 import dnd.studyplanner.domain.user.model.User;
-import dnd.studyplanner.dto.user.request.UserStudyGroupListDetailDto;
 import dnd.studyplanner.dto.user.response.UserStudyGroupListDetailResponse;
 import dnd.studyplanner.dto.user.response.groupList.StudyGroupListGetResponse;
 import dnd.studyplanner.dto.user.request.UserInfoExistDto;


### PR DESCRIPTION
### 스터디 그룹 상세 정보 조회 API

- API 테스트 과정에서, 상세 정보를 조회할 스터디 그룹의 구성원이 아닌 사용자가 API 를 호출하게 될 경우 USER_NOT_IN_GROUP 응답 추가

- HOME 에서 특정 스터디 그룹을 선택하고 -> 해당 페이지로 접속하므로 RequestParam 에서

    - groupId 필수
    - goalId 의 경우 해당 스터디 그룹의 목표 중, " CreatedDate 내림차순에 따른 가장 최근 goalId " 가 Defaul 로 설정

        - 이 부분이 Home 에서 그룹별 현재 진행중인 세부 목표를 조회하는 경우 적용하는 조건처럼 해야하는지 같이 정해주세욥!..!

    - version 의 경우 PERSONAL/TEAM 버전 중 PERSONAL 이 Defaul 로 설정

- API 호출 상황에 따른 테스트 시나리오 -> Notion API 명세서에 기록

    - 사용자에 따른 상황 가정해서 테스트 요청 드립니다! 