### PR TITLE
feat : 스터디 그룹 생성 및 사용자 초대 분리

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
+++ b/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
@@ -4,7 +4,9 @@ import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
 
 import java.util.List;
 
+import dnd.studyplanner.dto.studyGroup.request.StudyGroupInviteDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,7 +45,6 @@ public class StudyGroupController {
         return new CustomResponse<>(studyGroupCategoryList, SUCCESS).toResponseEntity();
     }
 
-
     // 그룹 생성 & 사용자 초대
     @PostMapping("/info")
     public ResponseEntity<CustomResponse> addStudyGroup(
@@ -73,6 +74,30 @@ public class StudyGroupController {
         } catch (IllegalArgumentException e) {
             return new CustomResponse<>(NOT_VALID_STATUS).toResponseEntity();
         }
+    }
+
+    // 스터디 그룹 생성
+    @PostMapping("/save")
+    public ResponseEntity<CustomResponse> saveStudyGroupOnly (
+            @RequestHeader(value = "Access-Token") String accessToken,
+            @RequestBody StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto) {
+
+        StudyGroupSaveResponse updateStudyGroup = studyGroupService.saveStudyGroupOnly(studyGroupSaveDto, userJoinGroupSaveDto, accessToken);
+
+        return new CustomResponse<>(updateStudyGroup, SAVE_GROUP_SUCCESS).toResponseEntity();
+
+    }
+
+    // 스터디 그룹 초대
+    @PostMapping("/invite")
+    public ResponseEntity<CustomResponse> groupInvite (
+            @RequestHeader(value = "Access-Token") String accessToken,
+            @RequestBody StudyGroupInviteDto studyGroupInviteDto, UserJoinGroupSaveDto userJoinGroupSaveDto) {
+
+        StudyGroupSaveResponse updateStudyGroup = studyGroupService.groupInvite(studyGroupInviteDto, userJoinGroupSaveDto, accessToken);
+
+        return new CustomResponse<>(updateStudyGroup, INVITE_USER_SUCCESS).toResponseEntity();
+
     }
 
 }

--- a/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
+++ b/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
@@ -16,6 +16,7 @@ public enum CustomResponseStatus {
 	GET_GROUP_SUCCESS(true, 1301, "사용자 가입 그룹 조회 성공", HttpStatus.OK),
 	GET_MY_GROUP_SUCCESS(true, 1302, "프로필 스터디 그룹 조회 성공", HttpStatus.OK),
 	GET_GROUP_DETAIL_SUCCESS(true, 1303, "스터디 그룹 상세 정보 조회 성공", HttpStatus.OK),
+	INVITE_USER_SUCCESS(true, 1304, "사용자 그룹 초대 성공", HttpStatus.OK),
 	SAVE_GOAL_SUCCESS(true, 1400, "목표 저장 성공", HttpStatus.OK),
 
 	//4000번 오류 응답코드

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/request/StudyGroupInviteDto.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/request/StudyGroupInviteDto.java
@@ -1,0 +1,11 @@
+package dnd.studyplanner.dto.studyGroup.request;
+
+import lombok.Getter;
+
+@Getter
+public class StudyGroupInviteDto {
+
+    private String userEmail;
+
+    private Long studyGroupId;
+}

--- a/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
@@ -2,9 +2,11 @@ package dnd.studyplanner.service;
 
 import java.util.List;
 
+import dnd.studyplanner.dto.studyGroup.request.StudyGroupInviteDto;
 import dnd.studyplanner.dto.studyGroup.response.MyStudyGroupPageResponse;
 import dnd.studyplanner.dto.studyGroup.response.MyStudyGroupResponse;
 import dnd.studyplanner.domain.studygroup.model.StudyGroupCategory;
+import dnd.studyplanner.dto.studyGroup.response.StudyGroupResponse;
 import dnd.studyplanner.dto.studyGroup.response.StudyGroupSaveResponse;
 import dnd.studyplanner.dto.studyGroup.request.StudyGroupSaveDto;
 import dnd.studyplanner.dto.userJoinGroup.request.UserJoinGroupSaveDto;
@@ -18,4 +20,7 @@ public interface IStudyGroupService {
 
 	List<StudyGroupCategory> getCategoryList(String accessToken);
 
+	StudyGroupSaveResponse saveStudyGroupOnly(StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto,String accessToken);
+
+	StudyGroupSaveResponse groupInvite(StudyGroupInviteDto studyGroupInviteDto, UserJoinGroupSaveDto userJoinGroupSaveDto, String accessToken);
 }


### PR DESCRIPTION
- 우선 기존에 스터디 그룹 생성 & 초대 일괄 처리 API 부분은 그대로 살려두고 
- 추가로 그룹 생성과 사용자 초대 분리해서 코드 추가해놨습니다 ! 


- 이후 진행 예정
    - 사용자 초대를 위한 이메일 입력 시 목록 조회
    - 초대 코드 생성 및 가입 처리 