### PR TITLE
Fix/options (진행중)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ logs
 jasyptKey.txt
 /src/main/java/dnd/studyplanner/config/SecretConstant.java
 .DS_Store
+/src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation("org.junit.vintage:junit-vintage-engine") {

--- a/src/main/java/dnd/studyplanner/config/WebMvcConfig.java
+++ b/src/main/java/dnd/studyplanner/config/WebMvcConfig.java
@@ -23,7 +23,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		registry.addInterceptor(jwtTokenInterceptor)
 			.addPathPatterns("/token/test/**")
 			.addPathPatterns("/**")
-			.excludePathPatterns("/css/**","/images/**","/js/**","/h2-console/**", "/profile")
+			.excludePathPatterns("/css/**","/images/**","/js/**","/h2-console/**", "/profile", "/favicon.ico")
 			.excludePathPatterns("oauth2/**", "/auth/token/reissue", "/user/exist");
 	}
 

--- a/src/main/java/dnd/studyplanner/config/WebMvcConfig.java
+++ b/src/main/java/dnd/studyplanner/config/WebMvcConfig.java
@@ -18,13 +18,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Value("${front-client.domain}")
 	public String DOMAIN_HOST;
 
-	public void addInterceptors(InterceptorRegistry registry) {
-		//Interceptor scope
-		registry.addInterceptor(jwtTokenInterceptor)
-			.addPathPatterns("/token/test/**")
-			.addPathPatterns("/**")
-			.excludePathPatterns("oauth2/**", "/auth/token/reissue", "/user/exist");
-	}
+	// public void addInterceptors(InterceptorRegistry registry) {
+	// 	//Interceptor scope
+	// 	registry.addInterceptor(jwtTokenInterceptor)
+	// 		.addPathPatterns("/token/test/**")
+	// 		.addPathPatterns("/**")
+	// 		.excludePathPatterns("oauth2/**", "/auth/token/reissue", "/user/exist");
+	// }
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/dnd/studyplanner/config/WebMvcConfig.java
+++ b/src/main/java/dnd/studyplanner/config/WebMvcConfig.java
@@ -18,13 +18,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Value("${front-client.domain}")
 	public String DOMAIN_HOST;
 
-	// public void addInterceptors(InterceptorRegistry registry) {
-	// 	//Interceptor scope
-	// 	registry.addInterceptor(jwtTokenInterceptor)
-	// 		.addPathPatterns("/token/test/**")
-	// 		.addPathPatterns("/**")
-	// 		.excludePathPatterns("oauth2/**", "/auth/token/reissue", "/user/exist");
-	// }
+	public void addInterceptors(InterceptorRegistry registry) {
+		//Interceptor scope
+		registry.addInterceptor(jwtTokenInterceptor)
+			.addPathPatterns("/token/test/**")
+			.addPathPatterns("/**")
+			.excludePathPatterns("/css/**","/images/**","/js/**","/h2-console/**", "/profile")
+			.excludePathPatterns("oauth2/**", "/auth/token/reissue", "/user/exist");
+	}
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
@@ -113,9 +113,7 @@ public class QuestionBookController {
 		@PathVariable Long questionBookId
 	) {
 		List<UserSolveQuestionResponse> response = questionBookService.getUserSolveDetails(accessToken,
-				questionBookId).stream()
-			.map(UserSolveQuestion::toResponseDto)
-			.collect(Collectors.toList());
+			questionBookId);
 
 		return new CustomResponse<>(response).toResponseEntity();
 	}

--- a/src/main/java/dnd/studyplanner/domain/option/model/Option.java
+++ b/src/main/java/dnd/studyplanner/domain/option/model/Option.java
@@ -44,6 +44,7 @@ public class Option extends BaseEntity {
 		this.optionContent = optionContent;
 		this.optionImageEnable = optionImageEnable;
 		this.optionImageUrl = optionImageUrl;
+		this.isAnswer = isAnswer;
 
 		question.getOptions().add(this);
 

--- a/src/main/java/dnd/studyplanner/domain/option/model/Option.java
+++ b/src/main/java/dnd/studyplanner/domain/option/model/Option.java
@@ -36,15 +36,20 @@ public class Option extends BaseEntity {
 	private String optionContent;
 	private boolean optionImageEnable;
 	private String optionImageUrl;
+	private boolean isAnswer;
 
 	@Builder
-	public Option(Question question, String optionContent, boolean optionImageEnable, String optionImageUrl) {
+	public Option(Question question, String optionContent, boolean optionImageEnable, String optionImageUrl, boolean isAnswer) {
 		this.question = question;
 		this.optionContent = optionContent;
 		this.optionImageEnable = optionImageEnable;
 		this.optionImageUrl = optionImageUrl;
 
 		question.getOptions().add(this);
+
+		if (isAnswer) {
+			question.countAnswer();
+		}
 	}
 
 	public OptionResponseDto toResponseDto() {

--- a/src/main/java/dnd/studyplanner/domain/question/model/Question.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/Question.java
@@ -43,6 +43,7 @@ public class Question extends BaseEntity {
 	private String questionContent;
 	private int questionAnswer;
 	private int answerCount = 0;
+	private String questionImage;
 
 	@Enumerated(EnumType.STRING)
 	private QuestionOptionType questionOptionType;
@@ -54,11 +55,12 @@ public class Question extends BaseEntity {
 	private List<UserSolveQuestion> userSolveQuestions = new ArrayList<>();
 
 	@Builder
-	public Question(QuestionBook questionBook, String questionContent, int questionAnswer, QuestionOptionType questionOptionType) {
+	public Question(QuestionBook questionBook, String questionContent, int questionAnswer, QuestionOptionType questionOptionType, String questionImage) {
 		this.questionBook = questionBook;
 		this.questionContent = questionContent;
 		this.questionAnswer = questionAnswer;
 		this.questionOptionType = questionOptionType;
+		this.questionImage = questionImage;
 
 		questionBook.getQuestions().add(this);
 	}
@@ -70,6 +72,7 @@ public class Question extends BaseEntity {
 	public QuestionResponseDto toResponseDto() {
 		return QuestionResponseDto.builder()
 			.questionId(this.getId())
+			.questionImage(this.questionImage)
 			.questionContent(this.getQuestionContent())
 			.optionList(this.getOptions().stream()
 				.map(Option::toResponseDto)

--- a/src/main/java/dnd/studyplanner/domain/question/model/Question.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/Question.java
@@ -42,6 +42,7 @@ public class Question extends BaseEntity {
 
 	private String questionContent;
 	private int questionAnswer;
+	private int answerCount = 0;
 	@Enumerated(EnumType.STRING)
 	private QuestionOptionType questionOptionType;
 
@@ -59,6 +60,10 @@ public class Question extends BaseEntity {
 		this.questionOptionType = questionOptionType;
 
 		questionBook.getQuestions().add(this);
+	}
+
+	public void countAnswer() {
+		this.answerCount += 1;
 	}
 
 	public QuestionResponseDto toResponseDto() {

--- a/src/main/java/dnd/studyplanner/domain/question/model/Question.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/Question.java
@@ -43,6 +43,7 @@ public class Question extends BaseEntity {
 	private String questionContent;
 	private int questionAnswer;
 	private int answerCount = 0;
+
 	@Enumerated(EnumType.STRING)
 	private QuestionOptionType questionOptionType;
 

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserCheckOption.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserCheckOption.java
@@ -1,0 +1,35 @@
+package dnd.studyplanner.domain.user.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+import dnd.studyplanner.domain.option.model.Option;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserCheckOption {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_check_option_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "option_id")
+	private Option option;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_solve_question_id")
+	private UserSolveQuestion userSolveQuestion;
+}

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserCheckOption.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserCheckOption.java
@@ -12,6 +12,7 @@ import javax.persistence.OneToOne;
 
 import dnd.studyplanner.domain.option.model.Option;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,4 +33,12 @@ public class UserCheckOption {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_solve_question_id")
 	private UserSolveQuestion userSolveQuestion;
+
+	@Builder
+	public UserCheckOption(Option option, UserSolveQuestion userSolveQuestion) {
+		this.option = option;
+		this.userSolveQuestion = userSolveQuestion;
+
+		userSolveQuestion.getUserCheckOptions().add(this);
+	}
 }

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestion.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestion.java
@@ -45,26 +45,26 @@ public class UserSolveQuestion {
 	@JoinColumn(name = "question_id")
 	private Question solveQuestion;
 
-	private int pickOption;
+	private int pickOption; //deprecate
 	private int answerOption;
-	private boolean rightCheck;
+	private boolean rightCheck; // 정답 유무
 
-	@OneToMany(mappedBy = "userSolveQuestion")
+	@OneToMany(mappedBy = "userSolveQuestion", cascade = CascadeType.ALL)
 	private List<UserCheckOption> userCheckOptions = new ArrayList<>();
 
 	@Builder
-	public UserSolveQuestion(User solveUser, Question solveQuestion, int pickOption) {
+	public UserSolveQuestion(User solveUser, Question solveQuestion) {
 		this.solveUser = solveUser;
 		this.solveQuestion = solveQuestion;
-		this.pickOption = pickOption;
-
 		this.solveQuestionBook = solveQuestion.getQuestionBook();
 		this.answerOption = solveQuestion.getQuestionAnswer();
-		this.rightCheck = (this.answerOption == this.pickOption);
 
 		solveQuestion.getUserSolveQuestions().add(this);
 	}
 
+	public void setRightCheck(boolean rightCheck) {
+		this.rightCheck = rightCheck;
+	}
 
 
 	public UserSolveQuestionResponse toResponseDto() {

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestion.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestion.java
@@ -1,7 +1,9 @@
 package dnd.studyplanner.domain.user.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -10,6 +12,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import dnd.studyplanner.domain.option.model.Option;
 import dnd.studyplanner.domain.question.model.Question;
@@ -45,6 +48,9 @@ public class UserSolveQuestion {
 	private int pickOption;
 	private int answerOption;
 	private boolean rightCheck;
+
+	@OneToMany(mappedBy = "userSolveQuestion")
+	private List<UserCheckOption> userCheckOptions = new ArrayList<>();
 
 	@Builder
 	public UserSolveQuestion(User solveUser, Question solveQuestion, int pickOption) {

--- a/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestion.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/UserSolveQuestion.java
@@ -65,15 +65,4 @@ public class UserSolveQuestion {
 	public void setRightCheck(boolean rightCheck) {
 		this.rightCheck = rightCheck;
 	}
-
-
-	public UserSolveQuestionResponse toResponseDto() {
-		return UserSolveQuestionResponse.builder()
-			.question(this.getSolveQuestion())
-			.answerOption(this.answerOption)
-			.pickOption(this.pickOption)
-			.rightCheck(this.rightCheck)
-			.build();
-	}
-
 }

--- a/src/main/java/dnd/studyplanner/dto/option/request/OptionSaveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/option/request/OptionSaveDto.java
@@ -1,5 +1,7 @@
 package dnd.studyplanner.dto.option.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import dnd.studyplanner.domain.option.model.Option;
 import dnd.studyplanner.domain.question.model.Question;
 import lombok.AccessLevel;
@@ -10,13 +12,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OptionSaveDto {
+
 	private String optionContent;
+
+	@JsonProperty("isAnswer")
+	private boolean isAnswer;
+
 	private boolean optionImageEnable;
 	private String optionImageUrl;
 
 	@Builder
-	public OptionSaveDto(String optionContent, boolean optionImageEnable, String optionImageUrl) {
+	public OptionSaveDto(String optionContent, boolean isAnswer, boolean optionImageEnable, String optionImageUrl) {
 		this.optionContent = optionContent;
+		this.isAnswer = isAnswer;
 		this.optionImageEnable = optionImageEnable;
 		this.optionImageUrl = optionImageUrl;
 	}
@@ -27,6 +35,7 @@ public class OptionSaveDto {
 			.optionContent(this.optionContent)
 			.optionImageEnable(this.optionImageEnable)
 			.optionImageUrl(this.optionImageUrl)
+			.isAnswer(this.isAnswer)
 			.build();
 	}
 }

--- a/src/main/java/dnd/studyplanner/dto/option/response/OptionSolvedDetailResponseDto.java
+++ b/src/main/java/dnd/studyplanner/dto/option/response/OptionSolvedDetailResponseDto.java
@@ -1,0 +1,26 @@
+package dnd.studyplanner.dto.option.response;
+
+import dnd.studyplanner.domain.option.model.Option;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionSolvedDetailResponseDto {
+	private Long optionId;
+	private String optionContent;
+	private String optionImageUrl;
+	private Boolean isChecked;
+	private Boolean isAnswerOption;
+
+	@Builder
+	public OptionSolvedDetailResponseDto(Option option, Boolean isChecked) {
+		this.optionId = option.getId();
+		this.optionContent = option.getOptionContent();
+		this.optionImageUrl = option.getOptionImageUrl();
+		this.isAnswerOption = option.isAnswer();
+		this.isChecked = isChecked;
+	}
+}

--- a/src/main/java/dnd/studyplanner/dto/question/request/QuestionListDto.java
+++ b/src/main/java/dnd/studyplanner/dto/question/request/QuestionListDto.java
@@ -17,15 +17,17 @@ import lombok.NoArgsConstructor;
 public class QuestionListDto {
 
 	private String questionContent;
+	private String questionImage;
 	private QuestionOptionType questionOptionType;
 
 	private List<OptionSaveDto> optionSaveDtoList;
 
 	@Builder
-	public QuestionListDto(String questionContent, QuestionOptionType questionOptionType, List<OptionSaveDto> optionSaveDtoList) {
+	public QuestionListDto(String questionContent, QuestionOptionType questionOptionType, List<OptionSaveDto> optionSaveDtoList, String questionImage) {
 		this.questionContent = questionContent;
 		this.questionOptionType = questionOptionType;
 		this.optionSaveDtoList = optionSaveDtoList;
+		this.questionImage = questionImage;
 	}
 
 	public Question toEntity(QuestionBook questionBook) {
@@ -33,6 +35,7 @@ public class QuestionListDto {
 			.questionContent(this.questionContent)
 			.questionBook(questionBook)
 			.questionOptionType(this.questionOptionType)
+			.questionImage(this.questionImage)
 			.build();
 	}
 }

--- a/src/main/java/dnd/studyplanner/dto/question/request/QuestionListDto.java
+++ b/src/main/java/dnd/studyplanner/dto/question/request/QuestionListDto.java
@@ -16,15 +16,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionListDto {
 
-	private int questionAnswer;
 	private String questionContent;
 	private QuestionOptionType questionOptionType;
 
 	private List<OptionSaveDto> optionSaveDtoList;
 
 	@Builder
-	public QuestionListDto(int questionAnswer, String questionContent, QuestionOptionType questionOptionType, List<OptionSaveDto> optionSaveDtoList) {
-		this.questionAnswer = questionAnswer;
+	public QuestionListDto(String questionContent, QuestionOptionType questionOptionType, List<OptionSaveDto> optionSaveDtoList) {
 		this.questionContent = questionContent;
 		this.questionOptionType = questionOptionType;
 		this.optionSaveDtoList = optionSaveDtoList;
@@ -33,7 +31,6 @@ public class QuestionListDto {
 	public Question toEntity(QuestionBook questionBook) {
 		return Question.builder()
 			.questionContent(this.questionContent)
-			.questionAnswer(this.questionAnswer)
 			.questionBook(questionBook)
 			.questionOptionType(this.questionOptionType)
 			.build();

--- a/src/main/java/dnd/studyplanner/dto/question/request/QuestionSolveDto.java
+++ b/src/main/java/dnd/studyplanner/dto/question/request/QuestionSolveDto.java
@@ -1,5 +1,7 @@
 package dnd.studyplanner.dto.question.request;
 
+import java.util.List;
+
 import dnd.studyplanner.domain.question.model.Question;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
@@ -12,19 +14,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionSolveDto {
 	private Long questionId;
-	private int checkAnswer;
-
-	@Builder
-	public QuestionSolveDto(Long questionId, int checkAnswer) {
-		this.questionId = questionId;
-		this.checkAnswer = checkAnswer;
-	}
+	private List<Long> checkOptionIdList;
 
 	public UserSolveQuestion toEntity(User solveUser, Question solveQuestion) {
 		return UserSolveQuestion.builder()
 			.solveUser(solveUser)
 			.solveQuestion(solveQuestion)
-			.pickOption(this.checkAnswer)
 			.build();
 	}
 }

--- a/src/main/java/dnd/studyplanner/dto/question/response/QuestionResponseDto.java
+++ b/src/main/java/dnd/studyplanner/dto/question/response/QuestionResponseDto.java
@@ -12,12 +12,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionResponseDto {
 	private Long questionId;
+	private String questionImage;
 	private String questionContent;
 	private List<OptionResponseDto> optionList;
 
 	@Builder
-	public QuestionResponseDto(Long questionId, String questionContent, List<OptionResponseDto> optionList) {
+	public QuestionResponseDto(Long questionId, String questionImage, String questionContent,
+		List<OptionResponseDto> optionList) {
 		this.questionId = questionId;
+		this.questionImage = questionImage;
 		this.questionContent = questionContent;
 		this.optionList = optionList;
 	}

--- a/src/main/java/dnd/studyplanner/dto/questionbook/response/UserSolveQuestionResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/questionbook/response/UserSolveQuestionResponse.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import dnd.studyplanner.domain.option.model.Option;
 import dnd.studyplanner.domain.question.model.Question;
 import dnd.studyplanner.dto.option.response.OptionResponseDto;
+import dnd.studyplanner.dto.option.response.OptionSolvedDetailResponseDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,21 +18,18 @@ public class UserSolveQuestionResponse {
 
 	private Long questionId;
 	private String questionContent;
-	private List<OptionResponseDto> optionList;
+	private String questionImage;
+	private List<OptionSolvedDetailResponseDto> optionList;
 
-	private int pickOption;
-	private int answerOption;
 	private boolean rightCheck;
 
 	@Builder
-	public UserSolveQuestionResponse(Question question, int pickOption, int answerOption, boolean rightCheck) {
-		this.questionId = question.getId();
-		this.questionContent = question.getQuestionContent();
-		this.optionList = question.getOptions().stream()
-			.map(Option::toResponseDto)
-			.collect(Collectors.toList());
-		this.pickOption = pickOption;
-		this.answerOption = answerOption;
+	public UserSolveQuestionResponse(Long questionId, String questionContent, String questionImage,
+		List<OptionSolvedDetailResponseDto> optionList, boolean rightCheck) {
+		this.questionId = questionId;
+		this.questionContent = questionContent;
+		this.questionImage = questionImage;
+		this.optionList = optionList;
 		this.rightCheck = rightCheck;
 	}
 }

--- a/src/main/java/dnd/studyplanner/repository/OptionRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/OptionRepository.java
@@ -9,5 +9,6 @@ import dnd.studyplanner.domain.option.model.Option;
 public interface OptionRepository extends JpaRepository<Option, Long> {
 
 	List<Option> findOptionsByQuestion_Id(Long questionId);
+	List<Option> findAllByQuestion_IdIn(List<Long> questionIdList);
 
 }

--- a/src/main/java/dnd/studyplanner/service/IOptionService.java
+++ b/src/main/java/dnd/studyplanner/service/IOptionService.java
@@ -3,7 +3,10 @@ package dnd.studyplanner.service;
 import java.util.List;
 
 import dnd.studyplanner.domain.option.model.Option;
+import dnd.studyplanner.domain.question.model.Question;
 
 public interface IOptionService {
 	void saveAllOptions(List<Option> options);
+
+	List<Option> findByAllByQuestionList(List<Question> questionList);
 }

--- a/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
@@ -17,7 +17,7 @@ public interface IQuestionBookService {
 
 	boolean solveQuestionBook(String accessToken, QuestionBookSolveDto requestDto) throws BaseException;
 
-	List<UserSolveQuestion> getUserSolveDetails(String accessToken, Long questionBookId);
+	List<UserSolveQuestionResponse> getUserSolveDetails(String accessToken, Long questionBookId);
 
 	public int getRecentQuestionBookCount(Long userId, Long goalId);
 

--- a/src/main/java/dnd/studyplanner/service/Impl/OptionService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/OptionService.java
@@ -2,6 +2,7 @@ package dnd.studyplanner.service.Impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,5 +41,10 @@ public class OptionService implements IOptionService {
 		optionRepository.saveAll(options);
 	}
 
+	@Override
+	public List<Option> findByAllByQuestionList(List<Question> questionList) {
+		return optionRepository.findAllByQuestion_IdIn(
+			questionList.stream().map(Question::getId).collect(Collectors.toList()));
+	}
 
 }


### PR DESCRIPTION
#70 
현) `Question` entity에 정답인 `option`의 **index**를 저장함 

문제점 → 정답이 여러개인 경우 저장하기 어려움

     → `option`의 순서를 랜덤으로 출제하지 못함

개선)

 `Question`에선 정답의 개수만 저장하도록 변경 (question_answer 삭제)

`option` 에서 해당 선택지가 정답인지에 대한 상태 저장

- [x]  엔티티 수정 (로컬에서 테스트 진행)
- [x]  문제 생성시 Reqeust Body 변경
    
    `Question`에서 정답 정보를 포함하지 않음
    
    → `questionAnswer` 삭제
    
    Option에 정답 정보 포함
    
    → `isAnswer` 추가
    
    이제 문제에 정답이 한 개 이상이 가능함

## TODO
- [x]  풀이시 다중 정답에 대해 포괄적으로 처리 가능하도록 변경
    - [x]  정답 유무 체크 (2개의 정답이 있는 문제에서 하나만 맞추는 경우 틀림)
    - [x]  사용자가 선택한 선택지 정보 저장 (1개 이상의 선택지를 선택 가능)

- [x]  문제 자세히 보기 시 다중 선택한 부분 포함하여 반환