### PR TITLE
Feature/question-book edit

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
+++ b/src/main/java/dnd/studyplanner/controller/QuestionBookController.java
@@ -3,19 +3,18 @@ package dnd.studyplanner.controller;
 import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import dnd.studyplanner.domain.user.model.UserGoalRate;
-import dnd.studyplanner.domain.user.model.UserSolveQuestion;
 import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
 import dnd.studyplanner.dto.questionbook.request.QuestionBookSolveDto;
 import dnd.studyplanner.dto.questionbook.response.QuestionBookSaveResponse;
@@ -120,6 +119,21 @@ public class QuestionBookController {
 			questionBookId);
 
 		return new CustomResponse<>(response).toResponseEntity();
+	}
+
+	@PutMapping("/{questionBookId}/edit")
+	public ResponseEntity<CustomResponse> editQuestionBook(
+		@RequestHeader("Access-Token") String accessToken,
+		@PathVariable Long questionBookId,
+		@RequestBody QuestionBookDto saveDto
+	) {
+		try {
+			questionBookService.editQuestionBook(accessToken, questionBookId, saveDto);
+			return new CustomResponse<>(EDIT_QUESTION_BOOK_SUCCESS).toResponseEntity();
+		} catch (BaseException e) {
+			return new CustomResponse<>(e.getStatus()).toResponseEntity();
+		}
+
 	}
 
 }

--- a/src/main/java/dnd/studyplanner/domain/question/model/Question.java
+++ b/src/main/java/dnd/studyplanner/domain/question/model/Question.java
@@ -21,6 +21,8 @@ import dnd.studyplanner.domain.base.BaseEntity;
 import dnd.studyplanner.domain.option.model.Option;
 import dnd.studyplanner.domain.questionbook.model.QuestionBook;
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
+import dnd.studyplanner.dto.option.request.OptionSaveDto;
+import dnd.studyplanner.dto.question.request.QuestionListDto;
 import dnd.studyplanner.dto.question.response.QuestionResponseDto;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -76,6 +78,17 @@ public class Question extends BaseEntity {
 				.map(Option::toResponseDto)
 				.collect(Collectors.toList()))
 			.build();
+	}
+
+	public void updateByEditDto(QuestionListDto editQuestionDto) {
+		this.questionContent = editQuestionDto.getQuestionContent();
+		this.questionImage = editQuestionDto.getQuestionImage();
+		this.questionOptionType = editQuestionDto.getQuestionOptionType();
+	}
+
+	public void clearOptions() {
+		this.answerCount = 0;
+		this.options.clear();
 	}
 
 }

--- a/src/main/java/dnd/studyplanner/domain/questionbook/model/QuestionBook.java
+++ b/src/main/java/dnd/studyplanner/domain/questionbook/model/QuestionBook.java
@@ -22,6 +22,7 @@ import dnd.studyplanner.domain.question.model.Question;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
 import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
+import dnd.studyplanner.dto.questionbook.request.QuestionBookDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -66,5 +67,10 @@ public class QuestionBook extends BaseEntity {
 		this.questionBookQuestionNum = questionBookQuestionNum;
 
 		questionBookGoal.getQuestionBooks().add(this);
+	}
+
+	public void updateByEditDto(QuestionBookDto saveDto) {
+		this.questionBookName = saveDto.getQuestionBookName();
+		this.questionBookQuestionNum = saveDto.getQuestionBookQuestionNum();
 	}
 }

--- a/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
+++ b/src/main/java/dnd/studyplanner/dto/response/CustomResponseStatus.java
@@ -18,6 +18,7 @@ public enum CustomResponseStatus {
 	GET_GROUP_DETAIL_SUCCESS(true, 1303, "스터디 그룹 상세 정보 조회 성공", HttpStatus.OK),
 	INVITE_USER_SUCCESS(true, 1304, "사용자 그룹 초대 성공", HttpStatus.OK),
 	SAVE_GOAL_SUCCESS(true, 1400, "목표 저장 성공", HttpStatus.OK),
+	EDIT_QUESTION_BOOK_SUCCESS(true, 1450, "문제집 정보가 변경 되었습니다", HttpStatus.OK),
 	FINISH_STUDY_GROUP_SUCCESS(true, 1500, "스터디 그룹이 완료 처리 되었습니다", HttpStatus.OK),
 
 	//4000번 오류 응답코드
@@ -36,8 +37,9 @@ public enum CustomResponseStatus {
 	UNAUTHORIZED_REQUEST(false, 4101, "권한이 없는 요청입니다.", HttpStatus.UNAUTHORIZED),
 
 	ALREADY_SOLVED_QUESTION_BOOK(false, 4200, "이미 풀이 완료한 문제집 입니다", HttpStatus.BAD_REQUEST),
-	UNAUTHORIZED_QUESTION_BOOK(false, 4201, "풀이 권한이 없는 문제집 입니다", HttpStatus.BAD_REQUEST),
-	QUESTION_AMOUNT_UNMATCHED(false, 4202, "현재 세부 목표의 문제 출제 개수와 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+	UNAUTHORIZED_QUESTION_BOOK(false, 4201, "풀이 권한이 없는 문제집 입니다", HttpStatus.UNAUTHORIZED),
+	QUESTION_AMOUNT_UNMATCHED(false, 4202, "현재 세부 목표의 문제 출제 개수와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+	QUESTION_BOOK_ALREADY_SOLVED(false, 4203, "다른 사용자가 푼 기록이 있는 문제집은 수정할 수 없습니다", HttpStatus.NOT_ACCEPTABLE);
 
 	private final boolean isSuccess;
 	private final int responseCode;

--- a/src/main/java/dnd/studyplanner/repository/OptionRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/OptionRepository.java
@@ -10,5 +10,5 @@ public interface OptionRepository extends JpaRepository<Option, Long> {
 
 	List<Option> findOptionsByQuestion_Id(Long questionId);
 	List<Option> findAllByQuestion_IdIn(List<Long> questionIdList);
-
+	void deleteByQuestionId(Long questionId);
 }

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -14,5 +14,5 @@ public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolve
 
 	Optional<UserSolveQuestionBook> findBySolveUserIdAndSolveQuestionBookId(Long userId, Long questionBookId);
 
-	List<UserSolveQuestionBook> findBySolveQuestionBookId(Long questionBookId);
+	boolean existsBySolveQuestionBookIdAndIsSolved(Long questionBookId, boolean solved);
 }

--- a/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
+++ b/src/main/java/dnd/studyplanner/repository/UserSolveQuestionBookRepository.java
@@ -13,4 +13,6 @@ public interface UserSolveQuestionBookRepository extends JpaRepository<UserSolve
 	List<UserSolveQuestionBook> findAllBySolveUser_IdOrderByCreatedDateDesc(Long id);
 
 	Optional<UserSolveQuestionBook> findBySolveUserIdAndSolveQuestionBookId(Long userId, Long questionBookId);
+
+	List<UserSolveQuestionBook> findBySolveQuestionBookId(Long questionBookId);
 }

--- a/src/main/java/dnd/studyplanner/service/IOptionService.java
+++ b/src/main/java/dnd/studyplanner/service/IOptionService.java
@@ -9,4 +9,6 @@ public interface IOptionService {
 	void saveAllOptions(List<Option> options);
 
 	List<Option> findByAllByQuestionList(List<Question> questionList);
+
+	void deleteByQuestion(Question question);
 }

--- a/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/IQuestionBookService.java
@@ -22,4 +22,6 @@ public interface IQuestionBookService {
 	public int getRecentQuestionBookCount(Long userId, Long goalId);
 
 	boolean isSolvedQuestionBook(String accessToken, Long questionBookId) throws BaseException;
+
+	void editQuestionBook(String accessToken, Long questionBookId, QuestionBookDto saveDto) throws BaseException;
 }

--- a/src/main/java/dnd/studyplanner/service/Impl/OptionService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/OptionService.java
@@ -47,4 +47,9 @@ public class OptionService implements IOptionService {
 			questionList.stream().map(Question::getId).collect(Collectors.toList()));
 	}
 
+	@Override
+	public void deleteByQuestion(Question question) {
+		optionRepository.deleteByQuestionId(question.getId());
+	}
+
 }

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -238,15 +238,13 @@ public class QuestionBookService implements IQuestionBookService {
 			throw new BaseException(QUESTION_AMOUNT_UNMATCHED);
 		}
 
+		questionBook.updateByEditDto(saveDto);
+
 		List<Question> questions = questionBook.getQuestions();
 		List<QuestionListDto> questionDtoList = saveDto.getQuestionDtoList();
 
 		// 풀이 정보가 변경되었는지 체크
-		int solvedUserCount = (int) userSolveQuestionBookRepository.findBySolveQuestionBookId(questionBookId).stream()
-			.filter(UserSolveQuestionBook::isSolved)
-			.count();
-
-		if (solvedUserCount > 0) {
+		if (userSolveQuestionBookRepository.existsBySolveQuestionBookIdAndIsSolved(questionBookId, true)) {
 			throw new BaseException(QUESTION_BOOK_ALREADY_SOLVED);
 		}
 

--- a/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
+++ b/src/main/java/dnd/studyplanner/service/Impl/QuestionBookService.java
@@ -3,7 +3,6 @@ package dnd.studyplanner.service.Impl;
 import static dnd.studyplanner.dto.response.CustomResponseStatus.*;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +26,6 @@ import dnd.studyplanner.domain.user.model.UserJoinGroup;
 import dnd.studyplanner.domain.user.model.UserSolveQuestion;
 import dnd.studyplanner.domain.user.model.UserSolveQuestionBook;
 import dnd.studyplanner.dto.option.request.OptionSaveDto;
-import dnd.studyplanner.dto.option.response.OptionResponseDto;
 import dnd.studyplanner.dto.option.response.OptionSolvedDetailResponseDto;
 import dnd.studyplanner.dto.question.request.QuestionListDto;
 import dnd.studyplanner.dto.question.request.QuestionSolveDto;
@@ -226,6 +224,48 @@ public class QuestionBookService implements IQuestionBookService {
 			userId, questionBookId).orElseThrow(() -> new BaseException(UNAUTHORIZED_QUESTION_BOOK));
 
 		return userSolveQuestionBook.isSolved();
+	}
+
+	@Override
+	public void editQuestionBook(String accessToken, Long questionBookId, QuestionBookDto saveDto) throws BaseException {
+		Long userId = jwtService.getUserId(accessToken);
+		QuestionBook questionBook = questionBookRepository.findById(questionBookId)
+			.orElseThrow(() -> new BaseException(NOT_EXIST_DATA));
+
+		if (!questionBook.getQuestionBookCreateUser().getId().equals(userId)) {
+			throw new BaseException(UNAUTHORIZED_REQUEST);
+		} else if (questionBook.getQuestionBookQuestionNum() != (saveDto.getQuestionDtoList().size())) {
+			throw new BaseException(QUESTION_AMOUNT_UNMATCHED);
+		}
+
+		List<Question> questions = questionBook.getQuestions();
+		List<QuestionListDto> questionDtoList = saveDto.getQuestionDtoList();
+
+		// 풀이 정보가 변경되었는지 체크
+		int solvedUserCount = (int) userSolveQuestionBookRepository.findBySolveQuestionBookId(questionBookId).stream()
+			.filter(UserSolveQuestionBook::isSolved)
+			.count();
+
+		if (solvedUserCount > 0) {
+			throw new BaseException(QUESTION_BOOK_ALREADY_SOLVED);
+		}
+
+		// 기존 문제의 개수와 수정 dto내 문제 개수가 동일함이 보장되어 있음
+		for (int i = 0; i < questions.size(); i++) {
+			Question question = questions.get(i);
+			QuestionListDto editQuestionDto = questionDtoList.get(i);
+			question.updateByEditDto(editQuestionDto);
+
+			// option의 개수는 달라 질 수 있어서 remove -> create로 동작
+			question.clearOptions();
+			optionService.deleteByQuestion(question);
+			for (OptionSaveDto optionSaveDto : editQuestionDto.getOptionSaveDtoList()) {
+				optionSaveDto.toEntity(question);
+			}
+
+		}
+
+		questionBookRepository.save(questionBook);
 	}
 
 	private boolean isPassedQuestionBook(Long userId, Long questionBookId, int answerCount) {


### PR DESCRIPTION
# 문제집 수정 API

#80 상황 1
1. [사용자A]가 아직 풀이여부가 없는 문제집 수정 페이지에 진입
2. 문제 편집 중 (페이지에서), 다른 팀원이 해당 문제집을 푼 경우
-> 문제집 수정 시, 풀이 여부 이중 체크

- [ ] 상황 2
1. [사용자B]가 문제집 풀이 페이지 진입 (풀이중)
2. 해당 문제집 출제자가 문제집 편집을 완료한 경우
-> 문제 완료 시, 문제집이 업데이트 되었는 지 체크