### PR TITLE
Fix/sign in

### DIFF
--- a/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
@@ -63,6 +63,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		response.setHeader("X-USER-EMAIL", user.getUserEmail());
 		response.setHeader("X-NEW-USER", String.valueOf(user.isNewUser()));
 
+		if (user.isNewUser()) {
+			user.updateNewUser();
+		}
+
 		String targetUrl = UriComponentsBuilder.fromUriString(CLIENT_DOMAIN + "/login")
 			.build().toUriString();
 

--- a/src/main/java/dnd/studyplanner/config/OAuthService.java
+++ b/src/main/java/dnd/studyplanner/config/OAuthService.java
@@ -44,7 +44,7 @@ public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2
 
 
 		// Social Service
-		// ex) Google, kakao, naver, ...
+		// ex) Google, Kakao, Naver
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
 		String userNameAttributeName = userRequest.getClientRegistration()
 			.getProviderDetails()

--- a/src/main/java/dnd/studyplanner/domain/user/model/User.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/User.java
@@ -81,4 +81,8 @@ public class User extends BaseEntity {
 		this.userProfileImageUrl = userProfileImageUrl;
 	}
 
+	public void updateNewUser() {
+		this.isNewUser = false;
+	}
+
 }

--- a/src/main/java/dnd/studyplanner/domain/user/model/User.java
+++ b/src/main/java/dnd/studyplanner/domain/user/model/User.java
@@ -47,6 +47,8 @@ public class User extends BaseEntity {
 	private String userRegion;
 	private String userProfileImageUrl;
 
+	private boolean isNewUser = true;
+
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
 	private List<UserJoinGroup> userJoinGroups = new ArrayList<>();
 


### PR DESCRIPTION
# 최초 로그인 정보 추가하여 응답하도록 수정
1. 최초 로그인 여부 상태를 가지는 필드 `isNewUser` 추가
2. 로그인 후 `isNewUser` 상태를 포함하여 응답
\+  header로 응답하도록 변경
3. 로그인 완료 후 `isNewUser` 상태 변경

### Response header
```shell
-h "X-ACCESS-TOKEN" : ""
-h "X-REFRESH-TOKEN" : ""
-h "X-USER-EMAIL" : "test@gmail.com"
-h "isNewUser" : true
```