### PR TITLE
fix : 소셜 로그인에 따라 응답 URL분리

### DIFF
--- a/src/main/java/dnd/studyplanner/config/Constant.java
+++ b/src/main/java/dnd/studyplanner/config/Constant.java
@@ -11,6 +11,7 @@ public class Constant {
 	public static String REFRESH_SECRET_KEY;
 
 	public static String CLIENT_DOMAIN;
+	public static String TEST_CLIENT_DOMAIN;
 
 	public static final int JWT_EXPIRATION = 1000 * 60 * 60 * 24 * 7; //2시간 -> 1주
 	public static final int REFRESH_EXPIRATION = 1000 * 60 * 60 * 24 * 7 * 2; //14일 (2주)
@@ -19,10 +20,12 @@ public class Constant {
 	public Constant(
 		@Value("${jwt.secret}") String jwtSecretKey,
 		@Value("${jwt.refresh-secret}") String refreshSecretKey,
-		@Value("${front-client.domain}") String clientDomain
+		@Value("${front-client.domain}") String clientDomain,
+		@Value("${front-client.test-domain}") String testClientDomain
 	) {
 		JWT_SECRET_KEY = jwtSecretKey;
 		REFRESH_SECRET_KEY = refreshSecretKey;
 		CLIENT_DOMAIN = clientDomain;
+		TEST_CLIENT_DOMAIN = testClientDomain;
 	}
 }

--- a/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dnd/studyplanner/config/OAuth2SuccessHandler.java
@@ -11,6 +11,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import dnd.studyplanner.auth.dto.AuthProvider;
 import dnd.studyplanner.domain.user.model.User;
 import dnd.studyplanner.repository.UserRepository;
 
@@ -67,10 +68,22 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			user.updateNewUser();
 		}
 
-		String targetUrl = UriComponentsBuilder.fromUriString(CLIENT_DOMAIN + "/login")
-			.build().toUriString();
+		String targetUrl = getTargetUrlByRequestURI(request.getRequestURI());
 
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+
+	// FIXME : 테스트 종료 후 없어질 Method
+	private String getTargetUrlByRequestURI(String requestURI) {
+		String[] directories = requestURI.split("/");
+		String providerInfo = directories[directories.length - 1];
+		if (AuthProvider.valueOf(providerInfo) == AuthProvider.kakao) {
+			return UriComponentsBuilder.fromUriString(TEST_CLIENT_DOMAIN + "/login")
+				.build().toUriString();
+		}
+
+		return UriComponentsBuilder.fromUriString(CLIENT_DOMAIN + "/login")
+			.build().toUriString();
 	}
 
 	// 정규표현식을 통한 이메일 추출 메서드


### PR DESCRIPTION
# 소셜 로그인후 Redirect URI 분리
1. oauth-client의 요청 URI로 소셜 로그인 종류 구분 ([해당 메소드](https://github.com/dnd-side-project/dnd-7th-9-backend/compare/master...TaeyeonRoyce:dnd-7th-9-backend:fix/sign-in-redirect?expand=1#diff-7dfd8db7e5151998e7c407d7ee1399158c221bca3e172a12e155938c738af247R76))
2. Test domain 추가

Kakao 로그인 -> localhost로 redirect
그 외, 프론트 도메인으로 redirect