### PR TITLE
fix : 스터디 그룹 조회 시 응답 수정

### DIFF
--- a/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
+++ b/src/main/java/dnd/studyplanner/controller/StudyGroupController.java
@@ -63,16 +63,10 @@ public class StudyGroupController {
 
     @GetMapping("/my")
     public ResponseEntity<CustomResponse> getMyStudyGroups(
-        @RequestHeader(value = "Access-Token") String accessToken,
-        @RequestParam(required = false) String status
+        @RequestHeader(value = "Access-Token") String accessToken
     ) {
         try {
-            if (status == null) {
-                status = "complete";
-            }
-
-            log.debug("[STUDY GROUP STATUS] : {}", status);
-            MyStudyGroupPageResponse response = studyGroupService.getUserStudyGroups(accessToken, status);
+            MyStudyGroupPageResponse response = studyGroupService.getUserStudyGroups(accessToken);
 
             return new CustomResponse<>(response, GET_MY_GROUP_SUCCESS).toResponseEntity();
         } catch (IllegalArgumentException e) {

--- a/src/main/java/dnd/studyplanner/dto/studyGroup/response/MyStudyGroupPageResponse.java
+++ b/src/main/java/dnd/studyplanner/dto/studyGroup/response/MyStudyGroupPageResponse.java
@@ -15,14 +15,22 @@ import lombok.NoArgsConstructor;
 public class MyStudyGroupPageResponse {
     private String profileImageUrl;
     private String nickname;
+    private Integer activeStudyGroupCount;
+    private Integer completeStudyGroupCount;
 
-    private List<MyStudyGroupResponse> studyGroupResponses;
+    private List<MyStudyGroupResponse> activeStudyGroupResponses;
+    private List<MyStudyGroupResponse> completeStudyGroupResponses;
 
     @Builder
-    public MyStudyGroupPageResponse(String profileImageUrl, String nickname,
-        List<MyStudyGroupResponse> studyGroupResponses) {
+    public MyStudyGroupPageResponse(String profileImageUrl, String nickname, Integer activeStudyGroupCount,
+        Integer completeStudyGroupCount,
+        List<MyStudyGroupResponse> activeStudyGroupResponses,
+        List<MyStudyGroupResponse> completeStudyGroupResponses) {
         this.profileImageUrl = profileImageUrl;
         this.nickname = nickname;
-        this.studyGroupResponses = studyGroupResponses;
+        this.activeStudyGroupCount = activeStudyGroupCount;
+        this.completeStudyGroupCount = completeStudyGroupCount;
+        this.activeStudyGroupResponses = activeStudyGroupResponses;
+        this.completeStudyGroupResponses = completeStudyGroupResponses;
     }
 }

--- a/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
+++ b/src/main/java/dnd/studyplanner/service/IStudyGroupService.java
@@ -17,7 +17,7 @@ public interface IStudyGroupService {
 
 	StudyGroupSaveResponse saveGroupAndInvite(StudyGroupSaveDto studyGroupSaveDto, UserJoinGroupSaveDto userJoinGroupSaveDto, String accessToken);
 
-	MyStudyGroupPageResponse getUserStudyGroups(String accessToken, String status);
+	MyStudyGroupPageResponse getUserStudyGroups(String accessToken);
 
 	List<StudyGroupCategory> getCategoryList(String accessToken);
 


### PR DESCRIPTION
# 내 스터디 그룹 조회 API 수정
1. 스터디 그룹의 상태와 관계없이 모두 응답하도록 변경
2. 상태에 따른 스터디 그룹의 개수 포함하여 응답
